### PR TITLE
[codex] Prepare first public release surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,28 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.0
+          run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Install dependencies
-        run: corepack pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build workspace
-        run: corepack pnpm build
+        run: pnpm build
 
       - name: Lint workspace
-        run: corepack pnpm lint
+        run: pnpm lint
 
       - name: Test workspace
-        run: corepack pnpm test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Install, build, lint, test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Build workspace
+        run: corepack pnpm build
+
+      - name: Lint workspace
+        run: corepack pnpm lint
+
+      - name: Test workspace
+        run: corepack pnpm test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+VITE_API_URL=http://localhost:4000
+
+# For a deployed preview or production build, point this at the reachable API base URL.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.app.json && vite build",
+    "lint": "tsc -p tsconfig.app.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Start here:
 - [Quickstart](./quickstart.md)
 - [Install](./install.md)
 - [Demo](./demo.md)
+- [Public release prep](./release-prep.md)
 - [LangGraph adapter](./adapters/langgraph.md)
 - [OpenHands adapter](./adapters/openhands.md)
 

--- a/docs/release-prep.md
+++ b/docs/release-prep.md
@@ -1,0 +1,68 @@
+# Public Release Prep
+
+This checklist is the honest boundary of what the current repo can support for the first public release.
+
+## What is ready
+
+- The repo builds, tests, and seeds a public demo loop locally.
+- The web shell already supports `VITE_API_URL`, so a deployed preview can point at a real API base URL.
+- The docs now explain the product surface without requiring a video.
+
+## Current blocker
+
+- The API is a separate Node HTTP server today, not a Vercel-hosted app in this repo.
+- A Vercel deployment of `apps/web` is only a real public demo if the API is already hosted somewhere reachable and `VITE_API_URL` points to it.
+- Do not publish the release as fully live until that API hosting path exists and is verified.
+
+## GitHub release and tag steps
+
+- [ ] Confirm the working tree is clean.
+- [ ] Run `corepack pnpm build`, `corepack pnpm lint`, and `corepack pnpm test` on a clean checkout.
+- [ ] Pick the first public tag name you will use, then create an annotated tag at the release commit.
+- [ ] Push the tag to GitHub once a remote exists.
+- [ ] Draft the GitHub release notes from the tag commit and summarize the public demo, the API boundary, and any known caveats.
+- [ ] Attach the screenshots and demo clip before marking the release public.
+
+## Screenshot and demo clip checklist
+
+Capture only seeded, public-safe content.
+
+- [ ] Hero / landing view showing `Live`, `Replay`, and `Optimize`.
+- [ ] `Live` room with a representative workflow selected.
+- [ ] `Replay` room showing the failure/evidence story.
+- [ ] `Optimize` room showing the promotion decision.
+- [ ] Mobile or narrow-layout shot if the public page is expected to be responsive.
+- [ ] One short demo clip that shows the full operator loop without exposing private data.
+- [ ] Verify every asset is readable at thumbnail size and does not rely on hidden context.
+
+## Vercel deployment checklist for the web/demo site
+
+These steps apply to `apps/web`, not the API server.
+
+- [ ] Create or link the Vercel project for this repo.
+- [ ] Set the root directory to `apps/web`.
+- [ ] Use the Vite build output (`dist`) as the deployment target.
+- [ ] Set `VITE_API_URL` to the reachable public API base URL.
+- [ ] Deploy a preview and confirm the page loads the seeded demo state.
+- [ ] Verify the deployed page can reach `/api/demo/state` through the configured API URL.
+- [ ] Add the custom domain in Vercel project settings only after the preview is confirmed.
+- [ ] Treat the latest production deployment as the source for the release domain.
+
+## Clean-machine verification checklist
+
+- [ ] Clone the repo into a fresh directory.
+- [ ] Run `corepack enable`.
+- [ ] Run `corepack pnpm install --frozen-lockfile`.
+- [ ] Run `corepack pnpm build`.
+- [ ] Run `corepack pnpm lint`.
+- [ ] Run `corepack pnpm test`.
+- [ ] Start the API with `corepack pnpm --filter @agent-studio/api dev`.
+- [ ] Start the web shell with `VITE_API_URL=http://localhost:4000 corepack pnpm --filter @agent-studio/web dev`.
+- [ ] Confirm the public demo loads and the seeded workflow renders.
+- [ ] Confirm `http://localhost:4000/health` and `http://localhost:4000/api/demo/state` respond as expected.
+
+## Release notes to call out
+
+- The public demo is seeded and read-only by design.
+- The web shell depends on a separately hosted API.
+- No live public GitHub release or production Vercel deployment should be claimed until those external steps are actually completed.

--- a/docs/release-prep.md
+++ b/docs/release-prep.md
@@ -11,8 +11,9 @@ This checklist is the honest boundary of what the current repo can support for t
 ## Current blocker
 
 - The API is a separate Node HTTP server today, not a Vercel-hosted app in this repo.
-- A Vercel deployment of `apps/web` is only a real public demo if the API is already hosted somewhere reachable and `VITE_API_URL` points to it.
-- Do not publish the release as fully live until that API hosting path exists and is verified.
+- It is not deployable as a standalone folder checkout: the current runtime expects workspace-root build outputs from internal packages such as `packages/contracts`, `packages/demo`, and the SDK/adapter packages.
+- A Vercel deployment of `apps/web` is only a real public demo if those monorepo build artifacts already exist and the API is hosted somewhere reachable with `VITE_API_URL` pointing at it.
+- Do not publish the release as fully live until that combined build-and-hosting path exists and is verified.
 
 ## GitHub release and tag steps
 
@@ -42,6 +43,7 @@ These steps apply to `apps/web`, not the API server.
 - [ ] Create or link the Vercel project for this repo.
 - [ ] Set the root directory to `apps/web`.
 - [ ] Use the Vite build output (`dist`) as the deployment target.
+- [ ] If the API is still running from this monorepo, make sure the workspace packages have already been built from the repo root before starting the API host.
 - [ ] Set `VITE_API_URL` to the reachable public API base URL.
 - [ ] Deploy a preview and confirm the page loads the seeded demo state.
 - [ ] Verify the deployed page can reach `/api/demo/state` through the configured API URL.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "corepack pnpm -r --if-present dev",
     "build": "corepack pnpm -r --if-present build",
-    "lint": "corepack pnpm build && corepack pnpm -r --if-present lint",
+    "lint": "corepack pnpm -r --if-present lint",
     "test": "corepack pnpm -r --if-present test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "corepack pnpm -r --if-present dev",
     "build": "corepack pnpm -r --if-present build",
-    "lint": "corepack pnpm -r --if-present lint",
+    "lint": "corepack pnpm build && corepack pnpm -r --if-present lint",
     "test": "corepack pnpm -r --if-present test"
   }
 }

--- a/packages/adapters/langgraph/package.json
+++ b/packages/adapters/langgraph/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.examples.json --noEmit",
     "test": "vitest run",
     "check:examples": "tsc -p tsconfig.examples.json --noEmit"
   },

--- a/packages/adapters/langgraph/package.json
+++ b/packages/adapters/langgraph/package.json
@@ -5,10 +5,10 @@
   "description": "LangGraph deployment adapter for Agent Studio",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -16,6 +16,7 @@
     "dist"
   ],
   "scripts": {
+    "lint": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,10 +5,10 @@
   "description": "Shared runtime contracts for Agent Studio",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -16,6 +16,7 @@
     "dist"
   ],
   "scripts": {
+    "lint": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -5,10 +5,10 @@
   "description": "Seeded demo dataset for Agent Studio",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.examples.json --noEmit",
     "test": "vitest run",
     "check:examples": "tsc -p tsconfig.examples.json --noEmit"
   },

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -5,10 +5,10 @@
   "description": "JavaScript SDK for Agent Studio",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },


### PR DESCRIPTION
## What changed

This PR prepares the standalone Agent Studio repo for its first public release surface.

It adds:
- GitHub Actions CI for install, build, lint, and test
- release-prep docs and checklists
- a web env example for `VITE_API_URL`
- standalone workspace lint/type resolution from a clean checkout

## Why it changed

The repo needed a real release-prep layer before we could publish it publicly. That meant the checks had to be trustworthy, the docs had to describe the actual deployment boundary, and the monorepo had to lint cleanly without hidden prior build state.

## Validation

Ran locally in `/Users/maximisto/Documents/agent-studio`:
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`
- `git diff --check`

Also validated from a fresh local clone:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`
- `git diff --check`

## Remaining external steps

This does not claim a live public launch yet.
Still needed:
- host the API
- link/deploy `apps/web` on Vercel with `VITE_API_URL`
- capture screenshots/demo clip
- publish the first tag and GitHub release
