### PR TITLE
[codex] Add combined Vercel demo deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+.vercel

--- a/api/router.ts
+++ b/api/router.ts
@@ -1,0 +1,43 @@
+type ApiApp = {
+  handle(request: Request): Promise<Response>;
+};
+
+let appPromise: Promise<ApiApp> | undefined;
+
+async function getApp(): Promise<ApiApp> {
+  if (!appPromise) {
+    appPromise = import('../apps/api/dist/server.js').then(({ createApiApp }) =>
+      createApiApp(),
+    );
+  }
+
+  return appPromise;
+}
+
+function buildForwardedUrl(request: Request): URL {
+  const incomingUrl = new URL(request.url);
+  const forwardedUrl = new URL(request.url);
+  const path = incomingUrl.searchParams.get('path');
+
+  if (path === 'health') {
+    forwardedUrl.pathname = '/health';
+  } else if (path) {
+    forwardedUrl.pathname = `/api/${path.replace(/^\/+/, '')}`;
+  } else {
+    forwardedUrl.pathname = '/api';
+  }
+
+  forwardedUrl.searchParams.delete('path');
+
+  return forwardedUrl;
+}
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const app = await getApp();
+    const forwardedUrl = buildForwardedUrl(request);
+    const forwardedRequest = new Request(forwardedUrl, request);
+
+    return app.handle(forwardedRequest);
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
     "build": "corepack pnpm -r --if-present build",
     "lint": "corepack pnpm -r --if-present lint",
     "test": "corepack pnpm -r --if-present test"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "typescript": "^5.6.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,14 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.29
+        version: 22.19.17
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
 
   apps/api:
     dependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "corepack pnpm install --frozen-lockfile",
+  "buildCommand": "corepack pnpm build",
+  "outputDirectory": "apps/web/dist",
+  "rewrites": [
+    {
+      "source": "/health",
+      "destination": "/api/router?path=health"
+    },
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/router?path=$1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a combined Vercel deployment path that serves the Vite demo and API from one project
- build workspace artifacts before the Vercel function runs
- route  and  through the serverless bridge

## Validation
- corepack pnpm lint
- corepack pnpm build
- corepack pnpm test
- deployed Vercel preview and verified , , and  via 