### PR TITLE
[codex] Align standalone studio with Violema control room

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 .vercel
+.env*.local

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 The open control room for multi-agent systems.
 
-This repo currently gives you a seeded local control-room demo plus a LangGraph ingest path. Agent Studio is runtime-agnostic, replay-first, evidence-backed, and built around a safe release loop. It is not another agent builder and it is not a generic RAG chat tool.
+Agent Studio is for teams running real agents and multi-agent systems who need to answer four practical questions:
+
+- What is running right now?
+- Which agents or systems are under pressure?
+- What exactly failed?
+- What should change before the next release?
+
+This repo currently gives you:
+
+- a public control-room demo
+- a runtime-agnostic control-plane contract
+- a bring-your-own ingest path
+- a shipped LangGraph adapter
+
+It is not another agent builder and it is not a generic RAG chat tool.
 
 ## Live demo
 
@@ -16,10 +30,50 @@ This repo currently gives you a seeded local control-room demo plus a LangGraph 
 - `apps/api` for the local API and ingest surface
 - `packages/contracts` for the shared runtime contract
 - `packages/sdk-js` for JS instrumentation
-- `packages/sdk-python` for the planned Python path
+- `packages/sdk-python` for the Python instrumentation path
 - `packages/demo` for the seeded demo dataset
 - `packages/adapters/langgraph` for the first shipped adapter
 - `packages/adapters/openhands` is planned, not shipped yet
+
+## Why this exists
+
+Most agent tooling is strong at one piece of the loop:
+
+- framework
+- tracing
+- evals
+- memory
+- prompt iteration
+
+Agent Studio is aimed at the operating loop across all of that:
+
+- ingest your systems
+- inspect fleet pressure
+- replay the failing path
+- compare the candidate change
+- release with evidence
+
+## Current product surface
+
+The current public demo already shows the core shape:
+
+- system-first overview instead of workflow-first storytelling
+- cross-system fleet overview and watchlist
+- searchable agent roster
+- execution and release history
+- time-windowed analytics
+- persistent hosted control-plane state on the public demo
+
+## Bring your own agents
+
+Agent Studio is built to ingest external systems instead of forcing you into one framework.
+
+- shipped first adapter:
+  - LangGraph
+- current generic path:
+  - control-plane ingest endpoints
+- planned next adapter:
+  - OpenHands
 
 ## Read This First
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,21 @@ This repo currently gives you a seeded local control-room demo plus a LangGraph 
 ## Public launch
 
 This repo is the standalone open-source surface for Agent Studio. The public demo reads seeded data from the API, and the API defaults to `http://localhost:4000`.
+
+## Persistence modes
+
+Agent Studio now supports three storage modes:
+
+- `memory`
+  - default fallback
+  - good for a seeded demo
+  - not durable across cold starts
+- `file`
+  - self-hosted persistence
+  - set `AGENT_STUDIO_STORE_FILE=/absolute/path/to/store.json`
+- `blob`
+  - hosted persistence for Vercel deployments
+  - uses `BLOB_READ_WRITE_TOKEN`
+  - optional `AGENT_STUDIO_BLOB_PATH` overrides the default snapshot path `control-plane/store.json`
+
+If `BLOB_READ_WRITE_TOKEN` is present, Agent Studio automatically prefers hosted blob persistence.

--- a/api/router.ts
+++ b/api/router.ts
@@ -6,8 +6,8 @@ let appPromise: Promise<ApiApp> | undefined;
 
 async function getApp(): Promise<ApiApp> {
   if (!appPromise) {
-    appPromise = import('../apps/api/dist/server.js').then(({ createApiApp }) =>
-      createApiApp(),
+    appPromise = import('../apps/api/dist/server.js').then(({ createDefaultApiApp }) =>
+      createDefaultApiApp(),
     );
   }
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@agent-studio/contracts": "workspace:*",
     "@agent-studio/demo": "workspace:*",
+    "@vercel/blob": "^2.3.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/api/src/control-plane-seed.ts
+++ b/apps/api/src/control-plane-seed.ts
@@ -1,0 +1,530 @@
+import type {
+  AgentDefinition,
+  ArtifactRecord,
+  EvaluationRecord,
+  ExecutionRecord,
+  InterventionRecord,
+  MetricDelta,
+  MetricSample,
+  ReleaseDecision,
+  Replay,
+  RuntimeRegistration,
+  SpanRecord,
+  SystemDefinition,
+  TopologyEdge,
+  TopologyNode,
+  TopologySnapshot,
+  Workflow,
+} from '@agent-studio/contracts';
+import { seededReplayByRunId } from '@agent-studio/demo';
+
+import { createSeededDemoState, type DemoStateResponse } from './demo-state.js';
+
+export interface SeededControlPlaneState {
+  runtimes: RuntimeRegistration[];
+  systems: SystemDefinition[];
+  agents: AgentDefinition[];
+  topologySnapshots: TopologySnapshot[];
+  executions: ExecutionRecord[];
+  spans: SpanRecord[];
+  artifacts: ArtifactRecord[];
+  metrics: MetricSample[];
+  interventions: InterventionRecord[];
+  evaluations: EvaluationRecord[];
+  releaseDecisions: ReleaseDecision[];
+}
+
+const DEMO_RUNTIME_ID = 'runtime_demo_seeded';
+const DEMO_ADAPTER_ID = 'seeded-demo';
+const DEMO_TIMESTAMP = '2026-04-20T13:12:00.000Z';
+
+function slug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+function buildSystemId(workflowId: string) {
+  return `system_${slug(workflowId)}`;
+}
+
+function buildAgentId(systemId: string, role: string) {
+  return `agent_${slug(systemId)}_${slug(role)}`;
+}
+
+function buildNodeId(agentId: string) {
+  return `node_${slug(agentId)}`;
+}
+
+function buildExecutionId(systemId: string, runId: string) {
+  return `execution_${slug(systemId)}_${slug(runId)}`;
+}
+
+function buildRuntimeRegistration(seed: DemoStateResponse): RuntimeRegistration {
+  const runtime = seed.runtimeOptions[0];
+
+  return {
+    runtimeId: DEMO_RUNTIME_ID,
+    kind: runtime?.id ?? 'demo',
+    adapterId: DEMO_ADAPTER_ID,
+    adapterVersion: 'v1',
+    label: runtime?.label ?? 'Seeded demo runtime',
+    capabilities: ['workflow-import', 'topology-derivation', 'replay-seeding', 'operational-context'],
+    sourceRef: 'seeded-demo-state',
+    createdAt: DEMO_TIMESTAMP,
+    updatedAt: DEMO_TIMESTAMP,
+    metadata: {
+      detail: runtime?.detail ?? 'Read-only seeded control-plane dataset.',
+    },
+  };
+}
+
+function collectRoles(workflow: Workflow, replay: Replay) {
+  return [...new Set([...workflow.steps.map((step) => step.assignedRole), ...replay.stepExecutions.map((step) => step.assignedRole)])];
+}
+
+function buildAgents(systemId: string, workflow: Workflow, replay: Replay): AgentDefinition[] {
+  const phasesByRole = new Map<string, Set<string>>();
+
+  workflow.steps.forEach((step) => {
+    const phases = phasesByRole.get(step.assignedRole) ?? new Set<string>();
+    phases.add(step.kind);
+    phasesByRole.set(step.assignedRole, phases);
+  });
+
+  return collectRoles(workflow, replay).map((role, index) => ({
+    agentId: buildAgentId(systemId, role),
+    systemId,
+    runtimeId: DEMO_RUNTIME_ID,
+    label: role.replace(/\b\w/g, (char) => char.toUpperCase()),
+    kind: index === 0 ? 'coordinator' : 'specialist',
+    role,
+    version: 'seeded-demo-v1',
+    capabilities: [...(phasesByRole.get(role) ?? new Set<string>())].sort(),
+    toolRefs: workflow.steps.filter((step) => step.assignedRole === role).flatMap((step) => (step.toolName ? [step.toolName] : [])),
+    memoryRefs: [],
+    status: 'active',
+    metadata: {
+      workflowId: workflow.workflowId,
+      stepCount: workflow.steps.filter((step) => step.assignedRole === role).length,
+    },
+  }));
+}
+
+function buildTopologyEdges(workflow: Workflow, agentByRole: Map<string, AgentDefinition>): TopologyEdge[] {
+  const stepById = new Map(workflow.steps.map((step) => [step.stepId, step] as const));
+  const seen = new Set<string>();
+  const edges: TopologyEdge[] = [];
+
+  workflow.steps.forEach((step, index) => {
+    const dependencyIds = step.dependsOnStepIds?.length ? step.dependsOnStepIds : index > 0 ? [workflow.steps[index - 1].stepId] : [];
+
+    dependencyIds.forEach((dependencyId) => {
+      const dependency = stepById.get(dependencyId);
+      if (!dependency) {
+        return;
+      }
+
+      const sourceAgent = agentByRole.get(dependency.assignedRole);
+      const targetAgent = agentByRole.get(step.assignedRole);
+      if (!sourceAgent || !targetAgent || sourceAgent.agentId === targetAgent.agentId) {
+        return;
+      }
+
+      const key = `${sourceAgent.agentId}->${targetAgent.agentId}`;
+      if (seen.has(key)) {
+        return;
+      }
+
+      seen.add(key);
+      edges.push({
+        edgeId: `edge_${slug(key)}`,
+        sourceNodeId: buildNodeId(sourceAgent.agentId),
+        targetNodeId: buildNodeId(targetAgent.agentId),
+        kind: 'handoff',
+        label: `${dependency.title} -> ${step.title}`,
+        metadata: {
+          sourceStepId: dependency.stepId,
+          targetStepId: step.stepId,
+        },
+      });
+    });
+  });
+
+  return edges;
+}
+
+function buildTopologySnapshot(systemId: string, workflow: Workflow, replay: Replay, executionId: string): TopologySnapshot {
+  const agents = buildAgents(systemId, workflow, replay);
+  const agentByRole = new Map(agents.map((agent) => [agent.role ?? agent.label, agent] as const));
+  const nodes: TopologyNode[] = agents.map((agent) => ({
+    nodeId: buildNodeId(agent.agentId),
+    agentId: agent.agentId,
+    runtimeId: agent.runtimeId,
+    label: agent.label,
+    kind: agent.kind,
+    role: agent.role,
+    clusterId: agent.kind === 'coordinator' ? 'command' : 'specialists',
+    metadata: {
+      capabilities: agent.capabilities,
+      toolRefs: agent.toolRefs,
+    },
+  }));
+
+  return {
+    snapshotId: `topology_${slug(systemId)}_${slug(executionId)}`,
+    systemId,
+    capturedAt: replay.run.finishedAt ?? replay.run.startedAt,
+    sourceExecutionId: executionId,
+    nodes,
+    edges: buildTopologyEdges(workflow, agentByRole),
+    layoutHints: {
+      layout: 'clustered-ring',
+      primaryCluster: 'command',
+    },
+    metadata: {
+      workflowId: workflow.workflowId,
+      derivedFrom: 'seeded-demo-workflow',
+    },
+  };
+}
+
+function buildSpanRecords(systemId: string, replay: Replay, agentByRole: Map<string, AgentDefinition>): SpanRecord[] {
+  const executionId = buildExecutionId(systemId, replay.run.runId);
+  const spanIdByStepId = new Map<string, string>();
+
+  return replay.stepExecutions.map((step, index) => {
+    const agent = agentByRole.get(step.assignedRole);
+    const spanId = `span_${slug(executionId)}_${slug(step.stepId)}_${index + 1}`;
+    const parentStepId = replay.workflow.steps.find((workflowStep) => workflowStep.stepId === step.stepId)?.dependsOnStepIds?.[0];
+    const parentSpanId = parentStepId ? spanIdByStepId.get(parentStepId) : index > 0 ? spanIdByStepId.get(replay.stepExecutions[index - 1].stepId) : undefined;
+
+    spanIdByStepId.set(step.stepId, spanId);
+
+    return {
+      spanId,
+      traceId: replay.run.runId,
+      executionId,
+      parentSpanId,
+      agentId: agent?.agentId,
+      nodeId: agent ? buildNodeId(agent.agentId) : undefined,
+      name: step.title,
+      kind: step.kind,
+      status: step.status,
+      startedAt: step.startedAt ?? replay.run.startedAt,
+      finishedAt: step.finishedAt ?? replay.run.finishedAt,
+      summary: step.summary ?? step.error,
+      usage: {
+        inputTokens: step.tokenUsage?.inputTokens,
+        outputTokens: step.tokenUsage?.outputTokens,
+        totalTokens: step.tokenUsage?.totalTokens,
+        credits: step.actualCredits,
+        durationMs: step.durationMs,
+        toolCalls: step.toolCalls,
+      },
+      attrs: {
+        assignedRole: step.assignedRole,
+        modelTier: step.modelTier,
+        modelSource: step.modelSource,
+        directiveMode: step.directiveMode,
+        directivePhases: step.directivePhases,
+        error: step.error,
+      },
+    };
+  });
+}
+
+function buildArtifacts(systemId: string, replay: Replay, spans: SpanRecord[], agentByRole: Map<string, AgentDefinition>): ArtifactRecord[] {
+  const executionId = buildExecutionId(systemId, replay.run.runId);
+  const artifacts: ArtifactRecord[] = spans.map((span, index) => ({
+    artifactId: `artifact_${slug(span.spanId)}_summary`,
+    kind: 'step-summary',
+    scopeType: 'span',
+    scopeId: span.spanId,
+    executionId,
+    spanId: span.spanId,
+    agentId: span.agentId,
+    summary: span.summary ?? `Summary for ${span.name}`,
+    metadata: {
+      order: index + 1,
+      workflowId: replay.workflow.workflowId,
+    },
+  }));
+
+  replay.operationalContext?.recommendationEvidence.forEach((evidence) => {
+    const agent = evidence.phase
+      ? agentByRole.get(
+          replay.stepExecutions.find((step) => step.kind === evidence.phase)?.assignedRole ??
+            replay.workflow.steps.find((step) => step.kind === evidence.phase)?.assignedRole ??
+            '',
+        )
+      : undefined;
+
+    artifacts.push({
+      artifactId: `artifact_${slug(executionId)}_${slug(evidence.evidenceId)}`,
+      kind: 'evidence',
+      scopeType: 'execution',
+      scopeId: executionId,
+      executionId,
+      agentId: agent?.agentId,
+      summary: evidence.body,
+      derivedFromArtifactIds: [],
+      metadata: {
+        title: evidence.title,
+        sourceLabel: evidence.sourceLabel,
+        phase: evidence.phase,
+        relatedRunIds: evidence.relatedRunIds,
+      },
+    });
+  });
+
+  return artifacts;
+}
+
+function buildExecutionMetrics(execution: ExecutionRecord, replay: Replay, spans: SpanRecord[]): MetricSample[] {
+  const finishedAt = execution.finishedAt ?? execution.startedAt;
+  const metrics: MetricSample[] = [
+    {
+      sampleId: `metric_${slug(execution.executionId)}_credits`,
+      metric: 'credits.actual',
+      unit: 'credits',
+      value: replay.run.actualCredits ?? 0,
+      ts: finishedAt,
+      scopeType: 'execution',
+      scopeId: execution.executionId,
+    },
+    {
+      sampleId: `metric_${slug(execution.executionId)}_duration`,
+      metric: 'duration.ms',
+      unit: 'ms',
+      value: replay.run.durationMs ?? 0,
+      ts: finishedAt,
+      scopeType: 'execution',
+      scopeId: execution.executionId,
+    },
+    {
+      sampleId: `metric_${slug(execution.executionId)}_success`,
+      metric: 'success.rate',
+      unit: 'ratio',
+      value: replay.run.status === 'succeeded' ? 1 : 0,
+      ts: finishedAt,
+      scopeType: 'execution',
+      scopeId: execution.executionId,
+    },
+  ];
+
+  spans.forEach((span) => {
+    if (span.usage?.durationMs != null) {
+      metrics.push({
+        sampleId: `metric_${slug(span.spanId)}_duration`,
+        metric: 'span.duration.ms',
+        unit: 'ms',
+        value: span.usage.durationMs,
+        ts: span.finishedAt ?? span.startedAt,
+        scopeType: 'span',
+        scopeId: span.spanId,
+      });
+    }
+
+    if (span.usage?.credits != null) {
+      metrics.push({
+        sampleId: `metric_${slug(span.spanId)}_credits`,
+        metric: 'span.credits',
+        unit: 'credits',
+        value: span.usage.credits,
+        ts: span.finishedAt ?? span.startedAt,
+        scopeType: 'span',
+        scopeId: span.spanId,
+      });
+    }
+  });
+
+  return metrics;
+}
+
+function buildMetricDeltas(workflowState: DemoStateResponse['workflowStates'][string]): MetricDelta[] {
+  const baseline = workflowState.optimize.baselineRun;
+  const candidate = workflowState.optimize.candidateRun;
+
+  return [
+    {
+      metric: 'credits.actual',
+      unit: 'credits',
+      baselineValue: baseline.actualCredits ?? 0,
+      candidateValue: candidate.actualCredits ?? 0,
+      delta: (candidate.actualCredits ?? 0) - (baseline.actualCredits ?? 0),
+    },
+    {
+      metric: 'duration.ms',
+      unit: 'ms',
+      baselineValue: baseline.durationMs ?? 0,
+      candidateValue: candidate.durationMs ?? 0,
+      delta: (candidate.durationMs ?? 0) - (baseline.durationMs ?? 0),
+    },
+  ];
+}
+
+export function createSeededControlPlaneState(seed: DemoStateResponse = createSeededDemoState()): SeededControlPlaneState {
+  const runtime = buildRuntimeRegistration(seed);
+  const systems: SystemDefinition[] = [];
+  const agents: AgentDefinition[] = [];
+  const topologySnapshots: TopologySnapshot[] = [];
+  const executions: ExecutionRecord[] = [];
+  const spans: SpanRecord[] = [];
+  const artifacts: ArtifactRecord[] = [];
+  const metrics: MetricSample[] = [];
+  const interventions: InterventionRecord[] = [];
+  const evaluations: EvaluationRecord[] = [];
+  const releaseDecisions: ReleaseDecision[] = [];
+
+  Object.values(seed.workflowStates).forEach((workflowState) => {
+    const workflow = workflowState.workflow;
+    const systemId = buildSystemId(workflow.workflowId);
+    const liveReplay = workflowState.live.replay;
+    const agentRecords = buildAgents(systemId, workflow, liveReplay);
+    const agentByRole = new Map(agentRecords.map((agent) => [agent.role ?? agent.label, agent] as const));
+    const liveExecutionId = buildExecutionId(systemId, workflowState.live.run.runId);
+
+    systems.push({
+      systemId,
+      workspaceId: workflow.workspaceId,
+      name: workflow.name,
+      description: workflow.description,
+      runtimeIds: [DEMO_RUNTIME_ID],
+      status: workflow.status,
+      primaryRuntimeId: DEMO_RUNTIME_ID,
+      policyRefs: workflow.policy
+        ? [`policy_${slug(workflow.workflowId)}_${slug(workflow.policy.mode)}_${slug(workflow.policy.reviewPolicy)}`]
+        : undefined,
+      createdAt: workflow.createdAt,
+      updatedAt: workflow.updatedAt,
+      metadata: {
+        workflowId: workflow.workflowId,
+        schedule: workflow.schedule,
+      },
+    });
+
+    agents.push(...agentRecords);
+
+    topologySnapshots.push(buildTopologySnapshot(systemId, workflow, liveReplay, liveExecutionId));
+
+    workflowState.runsByNewest.forEach((run) => {
+      const replay = seededReplayByRunId[run.runId as keyof typeof seededReplayByRunId];
+      if (!replay) {
+        return;
+      }
+
+      const execution: ExecutionRecord = {
+        executionId: buildExecutionId(systemId, run.runId),
+        systemId,
+        runtimeId: DEMO_RUNTIME_ID,
+        traceId: run.runId,
+        sessionId: workflow.workflowId,
+        workflowId: workflow.workflowId,
+        runId: run.runId,
+        status: run.status,
+        startedAt: run.startedAt,
+        finishedAt: run.finishedAt,
+        sourceRef: run.runId,
+        metadata: {
+          experimentId: run.experimentId,
+          experimentLabel: run.experimentLabel,
+          scenarioId: run.scenarioId,
+          previewPresetId: run.previewPresetId,
+        },
+      };
+
+      const spanRecords = buildSpanRecords(systemId, replay, agentByRole);
+      executions.push(execution);
+      spans.push(...spanRecords);
+      artifacts.push(...buildArtifacts(systemId, replay, spanRecords, agentByRole));
+      metrics.push(...buildExecutionMetrics(execution, replay, spanRecords));
+    });
+
+    const roleDirectives = workflowState.live.replay.studioState?.roleDirectives ?? {};
+    Object.entries(roleDirectives).forEach(([role, directive]) => {
+      const agent = agentByRole.get(role);
+      if (!agent) {
+        return;
+      }
+
+      interventions.push({
+        interventionId: `intervention_${slug(systemId)}_${slug(role)}_${slug(directive.mode)}`,
+        targetScopeType: 'agent',
+        targetScopeId: agent.agentId,
+        actor: 'seeded-demo',
+        action: `directive.${directive.mode}`,
+        reason: `Imported ${directive.mode} directive for ${role}.`,
+        requestedAt: directive.updatedAt ?? DEMO_TIMESTAMP,
+        appliedAt: directive.updatedAt ?? DEMO_TIMESTAMP,
+        outcome: 'active',
+        status: 'applied',
+        relatedTraceId: workflowState.live.run.runId,
+        configPatch: {
+          phases: directive.phases,
+        },
+        metadata: {
+          systemId,
+        },
+      });
+    });
+
+    evaluations.push({
+      evaluationId: `evaluation_${slug(systemId)}_${slug(workflowState.optimize.candidateRun.runId)}`,
+      targetScopeType: 'system',
+      targetScopeId: systemId,
+      baselineRefs: [workflowState.optimize.baselineRun.runId],
+      candidateRefs: [workflowState.optimize.candidateRun.runId],
+      metricDeltas: buildMetricDeltas(workflowState),
+      verdict: 'promote',
+      createdAt: workflowState.optimize.candidateRun.finishedAt ?? DEMO_TIMESTAMP,
+      summary: workflowState.optimize.promotionSummary,
+      metadata: {
+        candidatePlanId: workflowState.optimize.candidatePlan?.id,
+      },
+    });
+
+    workflowState.optimize.promotionHistory.forEach((promotion, index) => {
+      releaseDecisions.push({
+        releaseId: promotion.eventId || `release_${slug(systemId)}_${index + 1}`,
+        systemId,
+        candidateRef:
+          promotion.planId ??
+          promotion.sourceExperimentId ??
+          workflowState.optimize.candidateRun.runId,
+        baselineRef: workflowState.optimize.baselineRun.runId,
+        decision: promotion.mode === 'rollback' ? 'rollback' : 'promote',
+        evidenceRefs: promotion.sourceExperimentId ? [promotion.sourceExperimentId] : undefined,
+        rollbackPlan: promotion.mode === 'rollback' ? promotion.summary : undefined,
+        requestedAt: promotion.appliedAt,
+        appliedAt: promotion.appliedAt,
+        status: 'applied',
+        summary: promotion.summary,
+        metadata: {
+          mode: promotion.mode,
+          confidence: promotion.confidence,
+          creditsDelta: promotion.creditsDelta,
+          durationDelta: promotion.durationDelta,
+          successDelta: promotion.successDelta,
+        },
+      });
+    });
+  });
+
+  return {
+    runtimes: [runtime],
+    systems,
+    agents,
+    topologySnapshots,
+    executions,
+    spans,
+    artifacts,
+    metrics,
+    interventions,
+    evaluations,
+    releaseDecisions,
+  };
+}

--- a/apps/api/src/persistence.ts
+++ b/apps/api/src/persistence.ts
@@ -1,17 +1,31 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
+import { get, put } from '@vercel/blob';
+
 import type { ApiStoreSnapshot } from './store.js';
 import { ApiStore } from './store.js';
 
 export interface ApiStorageInfo {
-  mode: 'memory' | 'file';
+  mode: 'memory' | 'file' | 'blob';
   persistenceEnabled: boolean;
   filePath: string | null;
+  blobPath: string | null;
   detail: string;
 }
 
 const DEFAULT_STORE_FILE = '.agent-studio/store.json';
+const DEFAULT_BLOB_PATH = 'control-plane/store.json';
+
+function readStorageMode(env: NodeJS.ProcessEnv): 'memory' | 'file' | 'blob' | null {
+  const rawMode = env.AGENT_STUDIO_STORAGE_MODE?.trim().toLowerCase();
+
+  if (rawMode === 'memory' || rawMode === 'file' || rawMode === 'blob') {
+    return rawMode;
+  }
+
+  return null;
+}
 
 function resolveStoreFilePath(env: NodeJS.ProcessEnv) {
   const configuredPath = env.AGENT_STUDIO_STORE_FILE?.trim();
@@ -21,6 +35,16 @@ function resolveStoreFilePath(env: NodeJS.ProcessEnv) {
   }
 
   return resolve(configuredPath);
+}
+
+function resolveBlobPath(env: NodeJS.ProcessEnv) {
+  const configuredPath = env.AGENT_STUDIO_BLOB_PATH?.trim();
+
+  if (!configuredPath) {
+    return DEFAULT_BLOB_PATH;
+  }
+
+  return configuredPath.replace(/^\/+/, '');
 }
 
 function readSnapshotFromDisk(filePath: string): ApiStoreSnapshot | null {
@@ -45,50 +69,156 @@ function writeSnapshotToDisk(filePath: string, snapshot: ApiStoreSnapshot) {
   renameSync(tempPath, filePath);
 }
 
-export function getApiStorageInfo(env: NodeJS.ProcessEnv = process.env): ApiStorageInfo {
-  const configuredPath = resolveStoreFilePath(env);
+async function readSnapshotFromBlob(blobPath: string, token?: string) {
+  const result = await get(blobPath, {
+    access: 'private',
+    token,
+    useCache: false,
+  });
 
-  if (!configuredPath) {
+  if (!result || result.statusCode !== 200 || !result.stream) {
+    return null;
+  }
+
+  const raw = await new Response(result.stream).text();
+
+  if (!raw.trim()) {
+    return null;
+  }
+
+  return JSON.parse(raw) as ApiStoreSnapshot;
+}
+
+async function writeSnapshotToBlob(blobPath: string, snapshot: ApiStoreSnapshot, token?: string) {
+  await put(blobPath, `${JSON.stringify(snapshot, null, 2)}\n`, {
+    access: 'private',
+    allowOverwrite: true,
+    addRandomSuffix: false,
+    contentType: 'application/json',
+    cacheControlMaxAge: 60,
+    token,
+  });
+}
+
+export function getApiStorageInfo(env: NodeJS.ProcessEnv = process.env): ApiStorageInfo {
+  const explicitMode = readStorageMode(env);
+  const filePath = resolveStoreFilePath(env);
+  const blobPath = resolveBlobPath(env);
+  const blobToken = env.BLOB_READ_WRITE_TOKEN?.trim();
+
+  if (explicitMode === 'blob') {
+    if (blobToken) {
+      return {
+        mode: 'blob',
+        persistenceEnabled: true,
+        filePath: null,
+        blobPath,
+        detail: 'Persistent hosted Vercel Blob store for public imports, fleet history, and control-plane state.',
+      };
+    }
+
     return {
       mode: 'memory',
       persistenceEnabled: false,
       filePath: null,
-      detail: `Ephemeral in-memory store. Set AGENT_STUDIO_STORE_FILE to persist imports. Suggested default: ${DEFAULT_STORE_FILE}`,
+      blobPath,
+      detail: 'Blob mode was requested, but BLOB_READ_WRITE_TOKEN is missing. Falling back to ephemeral in-memory storage.',
+    };
+  }
+
+  if (explicitMode === 'file') {
+    if (filePath) {
+      return {
+        mode: 'file',
+        persistenceEnabled: true,
+        filePath,
+        blobPath: null,
+        detail: 'Persistent file-backed store for self-hosted Agent Studio deployments.',
+      };
+    }
+
+    return {
+      mode: 'memory',
+      persistenceEnabled: false,
+      filePath: null,
+      blobPath: null,
+      detail: `File mode was requested, but AGENT_STUDIO_STORE_FILE is missing. Falling back to ephemeral in-memory storage. Suggested default: ${DEFAULT_STORE_FILE}`,
+    };
+  }
+
+  if (blobToken) {
+    return {
+      mode: 'blob',
+      persistenceEnabled: true,
+      filePath: null,
+      blobPath,
+      detail: 'Persistent hosted Vercel Blob store for public imports, fleet history, and control-plane state.',
+    };
+  }
+
+  if (filePath) {
+    return {
+      mode: 'file',
+      persistenceEnabled: true,
+      filePath,
+      blobPath: null,
+      detail: 'Persistent file-backed store for self-hosted Agent Studio deployments.',
     };
   }
 
   return {
-    mode: 'file',
-    persistenceEnabled: true,
-    filePath: configuredPath,
-    detail: 'Persistent file-backed store for runtimes, systems, traces, interventions, and release history.',
+    mode: 'memory',
+    persistenceEnabled: false,
+    filePath: null,
+    blobPath: null,
+    detail: `Ephemeral in-memory store. Set AGENT_STUDIO_STORAGE_MODE=blob with BLOB_READ_WRITE_TOKEN for hosted persistence, or AGENT_STUDIO_STORE_FILE for self-hosted file persistence. Suggested file default: ${DEFAULT_STORE_FILE}`,
   };
 }
 
-export function createConfiguredStore(env: NodeJS.ProcessEnv = process.env) {
+export async function createConfiguredStore(env: NodeJS.ProcessEnv = process.env) {
   const storage = getApiStorageInfo(env);
 
-  if (storage.mode === 'memory' || !storage.filePath) {
+  if (storage.mode === 'blob' && storage.blobPath) {
+    const token = env.BLOB_READ_WRITE_TOKEN?.trim();
+    const snapshot = await readSnapshotFromBlob(storage.blobPath, token);
+    const store = new ApiStore(undefined, {
+      snapshot,
+      onChange(nextSnapshot) {
+        return writeSnapshotToBlob(storage.blobPath!, nextSnapshot, token);
+      },
+    });
+
+    if (!snapshot) {
+      await writeSnapshotToBlob(storage.blobPath, store.buildSnapshot(), token);
+    }
+
     return {
-      store: new ApiStore(),
+      store,
       storage,
     };
   }
 
-  const snapshot = readSnapshotFromDisk(storage.filePath);
-  const store = new ApiStore(undefined, {
-    snapshot,
-    onChange(nextSnapshot) {
-      writeSnapshotToDisk(storage.filePath!, nextSnapshot);
-    },
-  });
+  if (storage.mode === 'file' && storage.filePath) {
+    const snapshot = readSnapshotFromDisk(storage.filePath);
+    const store = new ApiStore(undefined, {
+      snapshot,
+      onChange(nextSnapshot) {
+        writeSnapshotToDisk(storage.filePath!, nextSnapshot);
+      },
+    });
 
-  if (!snapshot) {
-    writeSnapshotToDisk(storage.filePath, store.buildSnapshot());
+    if (!snapshot) {
+      writeSnapshotToDisk(storage.filePath, store.buildSnapshot());
+    }
+
+    return {
+      store,
+      storage,
+    };
   }
 
   return {
-    store,
+    store: new ApiStore(),
     storage,
   };
 }

--- a/apps/api/src/persistence.ts
+++ b/apps/api/src/persistence.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import type { ApiStoreSnapshot } from './store.js';
+import { ApiStore } from './store.js';
+
+export interface ApiStorageInfo {
+  mode: 'memory' | 'file';
+  persistenceEnabled: boolean;
+  filePath: string | null;
+  detail: string;
+}
+
+const DEFAULT_STORE_FILE = '.agent-studio/store.json';
+
+function resolveStoreFilePath(env: NodeJS.ProcessEnv) {
+  const configuredPath = env.AGENT_STUDIO_STORE_FILE?.trim();
+
+  if (!configuredPath) {
+    return null;
+  }
+
+  return resolve(configuredPath);
+}
+
+function readSnapshotFromDisk(filePath: string): ApiStoreSnapshot | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const raw = readFileSync(filePath, 'utf8');
+
+  if (!raw.trim()) {
+    return null;
+  }
+
+  return JSON.parse(raw) as ApiStoreSnapshot;
+}
+
+function writeSnapshotToDisk(filePath: string, snapshot: ApiStoreSnapshot) {
+  mkdirSync(dirname(filePath), { recursive: true });
+
+  const tempPath = `${filePath}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+  renameSync(tempPath, filePath);
+}
+
+export function getApiStorageInfo(env: NodeJS.ProcessEnv = process.env): ApiStorageInfo {
+  const configuredPath = resolveStoreFilePath(env);
+
+  if (!configuredPath) {
+    return {
+      mode: 'memory',
+      persistenceEnabled: false,
+      filePath: null,
+      detail: `Ephemeral in-memory store. Set AGENT_STUDIO_STORE_FILE to persist imports. Suggested default: ${DEFAULT_STORE_FILE}`,
+    };
+  }
+
+  return {
+    mode: 'file',
+    persistenceEnabled: true,
+    filePath: configuredPath,
+    detail: 'Persistent file-backed store for runtimes, systems, traces, interventions, and release history.',
+  };
+}
+
+export function createConfiguredStore(env: NodeJS.ProcessEnv = process.env) {
+  const storage = getApiStorageInfo(env);
+
+  if (storage.mode === 'memory' || !storage.filePath) {
+    return {
+      store: new ApiStore(),
+      storage,
+    };
+  }
+
+  const snapshot = readSnapshotFromDisk(storage.filePath);
+  const store = new ApiStore(undefined, {
+    snapshot,
+    onChange(nextSnapshot) {
+      writeSnapshotToDisk(storage.filePath!, nextSnapshot);
+    },
+  });
+
+  if (!snapshot) {
+    writeSnapshotToDisk(storage.filePath, store.buildSnapshot());
+  }
+
+  return {
+    store,
+    storage,
+  };
+}

--- a/apps/api/src/routes/control.ts
+++ b/apps/api/src/routes/control.ts
@@ -194,68 +194,90 @@ export async function handleControlIngestRoutes(request: Request, pathname: stri
   try {
     if (pathname === '/api/control/ingest/runtimes') {
       const items = await parseBatch(request, runtimeRegistrationSchema);
+      const result = store.upsertRuntimes(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertRuntimes(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/systems') {
       const items = await parseBatch(request, systemDefinitionSchema);
+      const result = store.upsertSystems(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertSystems(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/agents') {
       const items = await parseBatch(request, agentDefinitionSchema);
+      const result = store.upsertAgents(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertAgents(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/topologies') {
       const items = await parseBatch(request, topologySnapshotSchema);
+      const result = store.upsertTopologySnapshots(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertTopologySnapshots(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/executions') {
       const items = await parseBatch(request, executionRecordSchema);
+      const result = store.upsertExecutions(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertExecutions(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/spans') {
       const items = await parseBatch(request, spanRecordSchema);
+      const result = store.upsertSpans(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertSpans(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/artifacts') {
       const items = await parseBatch(request, artifactRecordSchema);
+      const result = store.upsertArtifacts(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertArtifacts(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/metrics') {
       const items = await parseBatch(request, metricSampleSchema);
+      const result = store.upsertMetrics(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertMetrics(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/interventions') {
       const items = await parseBatch(request, interventionRecordSchema);
+      const result = store.upsertInterventions(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertInterventions(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/evaluations') {
       const items = await parseBatch(request, evaluationRecordSchema);
+      const result = store.upsertEvaluations(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertEvaluations(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
 
     if (pathname === '/api/control/ingest/releases') {
       const items = await parseBatch(request, releaseDecisionSchema);
+      const result = store.upsertReleaseDecisions(items);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ items: store.upsertReleaseDecisions(items) }, { status: 201 });
+      return jsonResponse({ items: result }, { status: 201 });
     }
   } catch (error) {
     if (error instanceof ZodError) {

--- a/apps/api/src/routes/control.ts
+++ b/apps/api/src/routes/control.ts
@@ -1,0 +1,273 @@
+import {
+  agentDefinitionSchema,
+  artifactRecordSchema,
+  evaluationRecordSchema,
+  executionRecordSchema,
+  interventionRecordSchema,
+  metricSampleSchema,
+  releaseDecisionSchema,
+  runtimeRegistrationSchema,
+  spanRecordSchema,
+  systemDefinitionSchema,
+  topologySnapshotSchema,
+} from '@agent-studio/contracts';
+import { ZodError, z } from 'zod';
+
+import { errorResponse, jsonResponse, matchRoute, readJsonBody, validationErrorResponse } from '../http.js';
+import type { ApiStore } from '../store.js';
+
+function batchSchema<T>(schema: z.ZodType<T>) {
+  return z.union([schema, z.array(schema).min(1)]).transform((value) => (Array.isArray(value) ? value : [value]));
+}
+
+async function parseBatch<T>(request: Request, schema: z.ZodType<T>) {
+  const payload = await readJsonBody(request);
+
+  return batchSchema(schema).parse(payload);
+}
+
+export function handleControlReadRoutes(pathname: string, store: ApiStore): Response | null {
+  if (pathname === '/api/control/runtimes') {
+    return jsonResponse({ items: store.listRuntimes() });
+  }
+
+  const runtimeParams = matchRoute('/api/control/runtimes/:runtimeId', pathname);
+  if (runtimeParams) {
+    const runtime = store.getRuntime(runtimeParams.runtimeId);
+
+    return runtime ? jsonResponse({ item: runtime }) : errorResponse(404, `Runtime ${runtimeParams.runtimeId} was not found.`);
+  }
+
+  if (pathname === '/api/control/systems') {
+    return jsonResponse({ items: store.listSystems() });
+  }
+
+  const systemParams = matchRoute('/api/control/systems/:systemId', pathname);
+  if (systemParams) {
+    const system = store.getSystem(systemParams.systemId);
+
+    return system ? jsonResponse({ item: system }) : errorResponse(404, `System ${systemParams.systemId} was not found.`);
+  }
+
+  const systemAgentsParams = matchRoute('/api/control/systems/:systemId/agents', pathname);
+  if (systemAgentsParams) {
+    const system = store.getSystem(systemAgentsParams.systemId);
+    if (!system) {
+      return errorResponse(404, `System ${systemAgentsParams.systemId} was not found.`);
+    }
+
+    return jsonResponse({
+      system,
+      items: store.listAgentsBySystem(system.systemId),
+    });
+  }
+
+  const systemTopologyParams = matchRoute('/api/control/systems/:systemId/topology', pathname);
+  if (systemTopologyParams) {
+    const system = store.getSystem(systemTopologyParams.systemId);
+    if (!system) {
+      return errorResponse(404, `System ${systemTopologyParams.systemId} was not found.`);
+    }
+
+    const topology = store.getLatestTopologySnapshot(system.systemId);
+
+    return topology
+      ? jsonResponse({ system, item: topology })
+      : errorResponse(404, `System ${system.systemId} does not have a topology snapshot.`);
+  }
+
+  const systemExecutionsParams = matchRoute('/api/control/systems/:systemId/executions', pathname);
+  if (systemExecutionsParams) {
+    const system = store.getSystem(systemExecutionsParams.systemId);
+    if (!system) {
+      return errorResponse(404, `System ${systemExecutionsParams.systemId} was not found.`);
+    }
+
+    return jsonResponse({
+      system,
+      items: store.listExecutionsBySystem(system.systemId),
+    });
+  }
+
+  const systemInterventionsParams = matchRoute('/api/control/systems/:systemId/interventions', pathname);
+  if (systemInterventionsParams) {
+    const system = store.getSystem(systemInterventionsParams.systemId);
+    if (!system) {
+      return errorResponse(404, `System ${systemInterventionsParams.systemId} was not found.`);
+    }
+
+    return jsonResponse({
+      system,
+      items: store.listInterventionsBySystem(system.systemId),
+    });
+  }
+
+  const systemEvaluationsParams = matchRoute('/api/control/systems/:systemId/evaluations', pathname);
+  if (systemEvaluationsParams) {
+    const system = store.getSystem(systemEvaluationsParams.systemId);
+    if (!system) {
+      return errorResponse(404, `System ${systemEvaluationsParams.systemId} was not found.`);
+    }
+
+    return jsonResponse({
+      system,
+      items: store.listEvaluationsBySystem(system.systemId),
+    });
+  }
+
+  const systemReleasesParams = matchRoute('/api/control/systems/:systemId/releases', pathname);
+  if (systemReleasesParams) {
+    const system = store.getSystem(systemReleasesParams.systemId);
+    if (!system) {
+      return errorResponse(404, `System ${systemReleasesParams.systemId} was not found.`);
+    }
+
+    return jsonResponse({
+      system,
+      items: store.listReleaseDecisionsBySystem(system.systemId),
+    });
+  }
+
+  const agentParams = matchRoute('/api/control/agents/:agentId', pathname);
+  if (agentParams) {
+    const agent = store.getAgent(agentParams.agentId);
+
+    return agent ? jsonResponse({ item: agent }) : errorResponse(404, `Agent ${agentParams.agentId} was not found.`);
+  }
+
+  const executionParams = matchRoute('/api/control/executions/:executionId', pathname);
+  if (executionParams) {
+    const execution = store.getExecution(executionParams.executionId);
+
+    return execution
+      ? jsonResponse({ item: execution })
+      : errorResponse(404, `Execution ${executionParams.executionId} was not found.`);
+  }
+
+  const executionSpansParams = matchRoute('/api/control/executions/:executionId/spans', pathname);
+  if (executionSpansParams) {
+    const execution = store.getExecution(executionSpansParams.executionId);
+    if (!execution) {
+      return errorResponse(404, `Execution ${executionSpansParams.executionId} was not found.`);
+    }
+
+    return jsonResponse({
+      execution,
+      items: store.listSpansByExecution(execution.executionId),
+    });
+  }
+
+  const executionArtifactsParams = matchRoute('/api/control/executions/:executionId/artifacts', pathname);
+  if (executionArtifactsParams) {
+    const execution = store.getExecution(executionArtifactsParams.executionId);
+    if (!execution) {
+      return errorResponse(404, `Execution ${executionArtifactsParams.executionId} was not found.`);
+    }
+
+    return jsonResponse({
+      execution,
+      items: store.listArtifactsByExecution(execution.executionId),
+    });
+  }
+
+  const executionMetricsParams = matchRoute('/api/control/executions/:executionId/metrics', pathname);
+  if (executionMetricsParams) {
+    const execution = store.getExecution(executionMetricsParams.executionId);
+    if (!execution) {
+      return errorResponse(404, `Execution ${executionMetricsParams.executionId} was not found.`);
+    }
+
+    return jsonResponse({
+      execution,
+      items: store.listMetricsByScope('execution', execution.executionId),
+    });
+  }
+
+  return null;
+}
+
+export async function handleControlIngestRoutes(request: Request, pathname: string, store: ApiStore): Promise<Response | null> {
+  if (request.method !== 'POST') {
+    return null;
+  }
+
+  try {
+    if (pathname === '/api/control/ingest/runtimes') {
+      const items = await parseBatch(request, runtimeRegistrationSchema);
+
+      return jsonResponse({ items: store.upsertRuntimes(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/systems') {
+      const items = await parseBatch(request, systemDefinitionSchema);
+
+      return jsonResponse({ items: store.upsertSystems(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/agents') {
+      const items = await parseBatch(request, agentDefinitionSchema);
+
+      return jsonResponse({ items: store.upsertAgents(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/topologies') {
+      const items = await parseBatch(request, topologySnapshotSchema);
+
+      return jsonResponse({ items: store.upsertTopologySnapshots(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/executions') {
+      const items = await parseBatch(request, executionRecordSchema);
+
+      return jsonResponse({ items: store.upsertExecutions(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/spans') {
+      const items = await parseBatch(request, spanRecordSchema);
+
+      return jsonResponse({ items: store.upsertSpans(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/artifacts') {
+      const items = await parseBatch(request, artifactRecordSchema);
+
+      return jsonResponse({ items: store.upsertArtifacts(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/metrics') {
+      const items = await parseBatch(request, metricSampleSchema);
+
+      return jsonResponse({ items: store.upsertMetrics(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/interventions') {
+      const items = await parseBatch(request, interventionRecordSchema);
+
+      return jsonResponse({ items: store.upsertInterventions(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/evaluations') {
+      const items = await parseBatch(request, evaluationRecordSchema);
+
+      return jsonResponse({ items: store.upsertEvaluations(items) }, { status: 201 });
+    }
+
+    if (pathname === '/api/control/ingest/releases') {
+      const items = await parseBatch(request, releaseDecisionSchema);
+
+      return jsonResponse({ items: store.upsertReleaseDecisions(items) }, { status: 201 });
+    }
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return validationErrorResponse(error);
+    }
+
+    if (error instanceof Error) {
+      return errorResponse(400, error.message);
+    }
+
+    return errorResponse(400, 'Request could not be processed.');
+  }
+
+  return null;
+}

--- a/apps/api/src/routes/ingest.ts
+++ b/apps/api/src/routes/ingest.ts
@@ -32,26 +32,34 @@ export async function handleIngestRoutes(request: Request, pathname: string, sto
   try {
     if (pathname === '/api/ingest/workflows') {
       const payload = workflowSchema.parse(await readJsonBody(request));
+      const workflow = store.upsertWorkflow(payload);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ workflow: store.upsertWorkflow(payload) }, { status: 201 });
+      return jsonResponse({ workflow }, { status: 201 });
     }
 
     if (pathname === '/api/ingest/runs') {
       const payload = runSchema.parse(await readJsonBody(request));
+      const run = store.upsertRun(payload);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ run: store.upsertRun(payload) }, { status: 201 });
+      return jsonResponse({ run }, { status: 201 });
     }
 
     if (pathname === '/api/ingest/replays') {
       const payload = ingestReplaySchema.parse(await readJsonBody(request));
+      const replay = store.upsertReplay(payload);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ replay: store.upsertReplay(payload) }, { status: 201 });
+      return jsonResponse({ replay }, { status: 201 });
     }
 
     if (pathname === '/api/ingest/operational-contexts') {
       const payload = reachableOperationalContextSchema.parse(await readJsonBody(request));
+      const operationalContext = store.upsertOperationalContext(payload);
+      await store.flushPendingPersistence();
 
-      return jsonResponse({ operationalContext: store.upsertOperationalContext(payload) }, { status: 201 });
+      return jsonResponse({ operationalContext }, { status: 201 });
     }
   } catch (error) {
     if (error instanceof ZodError) {

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -290,7 +290,7 @@ describe('Agent Studio API', () => {
     };
 
     try {
-      const firstConfiguredStore = createConfiguredStore(env);
+      const firstConfiguredStore = await createConfiguredStore(env);
       const firstApp = createApiApp(firstConfiguredStore);
 
       const runtimeId = 'runtime_persisted';
@@ -330,7 +330,7 @@ describe('Agent Studio API', () => {
 
       expect(systemResponse.status).toBe(201);
 
-      const secondConfiguredStore = createConfiguredStore(env);
+      const secondConfiguredStore = await createConfiguredStore(env);
       const secondApp = createApiApp(secondConfiguredStore);
 
       const metaResponse = await secondApp.handle(new Request('http://agent-studio.test/api/control/meta'));

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -80,6 +80,203 @@ describe('Agent Studio API', () => {
     );
   });
 
+  it('serves the seeded control-plane registry and telemetry surfaces', async () => {
+    const app = createApiApp();
+
+    const systemsResponse = await app.handle(new Request('http://agent-studio.test/api/control/systems'));
+    expect(systemsResponse.status).toBe(200);
+    const systemsPayload = (await systemsResponse.json()) as {
+      items: Array<{ systemId: string; name: string }>;
+    };
+    expect(systemsPayload.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: seededWorkflow.name,
+        }),
+      ]),
+    );
+
+    const systemId = systemsPayload.items[0]?.systemId;
+    expect(systemId).toBeTruthy();
+
+    const agentsResponse = await app.handle(new Request(`http://agent-studio.test/api/control/systems/${systemId}/agents`));
+    expect(agentsResponse.status).toBe(200);
+    await expect(agentsResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            label: expect.any(String),
+            runtimeId: expect.any(String),
+          }),
+        ]),
+      }),
+    );
+
+    const topologyResponse = await app.handle(new Request(`http://agent-studio.test/api/control/systems/${systemId}/topology`));
+    expect(topologyResponse.status).toBe(200);
+    await expect(topologyResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          systemId,
+          nodes: expect.any(Array),
+          edges: expect.any(Array),
+        }),
+      }),
+    );
+
+    const executionsResponse = await app.handle(new Request(`http://agent-studio.test/api/control/systems/${systemId}/executions`));
+    expect(executionsResponse.status).toBe(200);
+    const executionsPayload = (await executionsResponse.json()) as {
+      items: Array<{ executionId: string; traceId: string }>;
+    };
+    expect(executionsPayload.items.length).toBeGreaterThan(0);
+
+    const executionId = executionsPayload.items[0]?.executionId;
+    expect(executionId).toBeTruthy();
+
+    const spansResponse = await app.handle(new Request(`http://agent-studio.test/api/control/executions/${executionId}/spans`));
+    expect(spansResponse.status).toBe(200);
+    await expect(spansResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            executionId,
+            name: expect.any(String),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('accepts batched control-plane ingest payloads and exposes them through registry routes', async () => {
+    const app = createApiApp();
+    const runtimeId = 'runtime_test_custom';
+    const systemId = 'system_test_custom';
+    const executionId = 'execution_test_custom';
+
+    const runtimesResponse = await app.handle(
+      new Request('http://agent-studio.test/api/control/ingest/runtimes', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify([
+          {
+            runtimeId,
+            kind: 'custom',
+            adapterId: 'custom-rest',
+            label: 'Custom runtime',
+          },
+        ]),
+      }),
+    );
+
+    expect(runtimesResponse.status).toBe(201);
+
+    const systemsResponse = await app.handle(
+      new Request('http://agent-studio.test/api/control/ingest/systems', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          systemId,
+          workspaceId: seededWorkflow.workspaceId,
+          name: 'Imported custom system',
+          runtimeIds: [runtimeId],
+        }),
+      }),
+    );
+
+    expect(systemsResponse.status).toBe(201);
+
+    const agentsResponse = await app.handle(
+      new Request('http://agent-studio.test/api/control/ingest/agents', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          agentId: 'agent_test_custom',
+          systemId,
+          runtimeId,
+          label: 'Custom analyst',
+          kind: 'specialist',
+        }),
+      }),
+    );
+
+    expect(agentsResponse.status).toBe(201);
+
+    const executionsResponse = await app.handle(
+      new Request('http://agent-studio.test/api/control/ingest/executions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          executionId,
+          systemId,
+          runtimeId,
+          traceId: 'trace_test_custom',
+          status: 'running',
+          startedAt: '2026-04-22T15:00:00.000Z',
+        }),
+      }),
+    );
+
+    expect(executionsResponse.status).toBe(201);
+
+    const spansResponse = await app.handle(
+      new Request('http://agent-studio.test/api/control/ingest/spans', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify([
+          {
+            spanId: 'span_test_custom_1',
+            traceId: 'trace_test_custom',
+            executionId,
+            agentId: 'agent_test_custom',
+            name: 'Collect custom evidence',
+            kind: 'search',
+            status: 'running',
+            startedAt: '2026-04-22T15:00:05.000Z',
+          },
+        ]),
+      }),
+    );
+
+    expect(spansResponse.status).toBe(201);
+
+    const readSystemResponse = await app.handle(new Request(`http://agent-studio.test/api/control/systems/${systemId}`));
+    expect(readSystemResponse.status).toBe(200);
+    await expect(readSystemResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          systemId,
+          runtimeIds: [runtimeId],
+        }),
+      }),
+    );
+
+    const readExecutionResponse = await app.handle(
+      new Request(`http://agent-studio.test/api/control/executions/${executionId}/spans`),
+    );
+    expect(readExecutionResponse.status).toBe(200);
+    await expect(readExecutionResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            spanId: 'span_test_custom_1',
+            executionId,
+          }),
+        ]),
+      }),
+    );
+  });
+
   it('rejects ingest payloads that do not match the shared contracts', async () => {
     const app = createApiApp();
 

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -1,5 +1,10 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
 import { seededOperationalContexts, seededReplays, seededWorkflow } from '@agent-studio/demo';
 
+import { createConfiguredStore } from './persistence';
 import { createApiApp } from './server';
 
 describe('Agent Studio API', () => {
@@ -275,6 +280,84 @@ describe('Agent Studio API', () => {
         ]),
       }),
     );
+  });
+
+  it('persists imported control-plane state when a file store is configured', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'agent-studio-store-'));
+    const env = {
+      ...process.env,
+      AGENT_STUDIO_STORE_FILE: join(tempDir, 'store.json'),
+    };
+
+    try {
+      const firstConfiguredStore = createConfiguredStore(env);
+      const firstApp = createApiApp(firstConfiguredStore);
+
+      const runtimeId = 'runtime_persisted';
+      const systemId = 'system_persisted';
+
+      const runtimeResponse = await firstApp.handle(
+        new Request('http://agent-studio.test/api/control/ingest/runtimes', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            runtimeId,
+            kind: 'custom',
+            adapterId: 'persisted-rest',
+            label: 'Persisted runtime',
+          }),
+        }),
+      );
+
+      expect(runtimeResponse.status).toBe(201);
+
+      const systemResponse = await firstApp.handle(
+        new Request('http://agent-studio.test/api/control/ingest/systems', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            systemId,
+            workspaceId: 'workspace_persisted',
+            name: 'Persisted system',
+            runtimeIds: [runtimeId],
+          }),
+        }),
+      );
+
+      expect(systemResponse.status).toBe(201);
+
+      const secondConfiguredStore = createConfiguredStore(env);
+      const secondApp = createApiApp(secondConfiguredStore);
+
+      const metaResponse = await secondApp.handle(new Request('http://agent-studio.test/api/control/meta'));
+      expect(metaResponse.status).toBe(200);
+      await expect(metaResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          item: expect.objectContaining({
+            mode: 'file',
+            persistenceEnabled: true,
+            filePath: env.AGENT_STUDIO_STORE_FILE,
+          }),
+        }),
+      );
+
+      const persistedSystemResponse = await secondApp.handle(new Request(`http://agent-studio.test/api/control/systems/${systemId}`));
+      expect(persistedSystemResponse.status).toBe(200);
+      await expect(persistedSystemResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          item: expect.objectContaining({
+            systemId,
+            name: 'Persisted system',
+          }),
+        }),
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('rejects ingest payloads that do not match the shared contracts', async () => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,5 +1,6 @@
 import { createServer } from 'node:http';
 
+import { handleControlIngestRoutes, handleControlReadRoutes } from './routes/control.js';
 import { handleDemoRoutes } from './routes/demo.js';
 import { handleIngestRoutes } from './routes/ingest.js';
 import { handleReplayRoutes } from './routes/replay.js';
@@ -54,11 +55,21 @@ export function createApiApp(store = new ApiStore()): ApiApp {
         if (runResponse) {
           return runResponse;
         }
+
+        const controlResponse = handleControlReadRoutes(url.pathname, store);
+        if (controlResponse) {
+          return controlResponse;
+        }
       }
 
       const ingestResponse = await handleIngestRoutes(request, url.pathname, store);
       if (ingestResponse) {
         return ingestResponse;
+      }
+
+      const controlIngestResponse = await handleControlIngestRoutes(request, url.pathname, store);
+      if (controlIngestResponse) {
+        return controlIngestResponse;
       }
 
       return errorResponse(404, `No route matched ${request.method} ${url.pathname}.`);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -7,16 +7,27 @@ import { handleReplayRoutes } from './routes/replay.js';
 import { handleRunRoutes } from './routes/runs.js';
 import { handleWorkflowRoutes } from './routes/workflows.js';
 import { errorResponse, jsonResponse, toRequest, writeResponse } from './http.js';
+import { createConfiguredStore, getApiStorageInfo, type ApiStorageInfo } from './persistence.js';
 import { ApiStore } from './store.js';
 
 export interface ApiApp {
   readonly store: ApiStore;
+  readonly storage: ApiStorageInfo;
   handle(request: Request): Promise<Response>;
 }
 
-export function createApiApp(store = new ApiStore()): ApiApp {
+interface CreateApiAppOptions {
+  store?: ApiStore;
+  storage?: ApiStorageInfo;
+}
+
+export function createApiApp(options: CreateApiAppOptions = {}): ApiApp {
+  const store = options.store ?? new ApiStore();
+  const storage = options.storage ?? getApiStorageInfo();
+
   return {
     store,
+    storage,
     async handle(request: Request): Promise<Response> {
       const url = new URL(request.url);
 
@@ -33,6 +44,12 @@ export function createApiApp(store = new ApiStore()): ApiApp {
 
       if (url.pathname === '/health') {
         return jsonResponse({ ok: true });
+      }
+
+      if (request.method === 'GET' && url.pathname === '/api/control/meta') {
+        return jsonResponse({
+          item: storage,
+        });
       }
 
       if (request.method === 'GET') {
@@ -78,7 +95,11 @@ export function createApiApp(store = new ApiStore()): ApiApp {
 }
 
 export function startApiServer(port = Number(process.env.PORT ?? 4000)) {
-  const app = createApiApp();
+  const { store, storage } = createConfiguredStore();
+  const app = createApiApp({
+    store,
+    storage,
+  });
   const server = createServer(async (request, response) => {
     const result = await app.handle(toRequest(request));
     result.headers.set('access-control-allow-origin', '*');

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -21,6 +21,15 @@ interface CreateApiAppOptions {
   storage?: ApiStorageInfo;
 }
 
+export async function createDefaultApiApp(env: NodeJS.ProcessEnv = process.env) {
+  const { store, storage } = await createConfiguredStore(env);
+
+  return createApiApp({
+    store,
+    storage,
+  });
+}
+
 export function createApiApp(options: CreateApiAppOptions = {}): ApiApp {
   const store = options.store ?? new ApiStore();
   const storage = options.storage ?? getApiStorageInfo();
@@ -94,12 +103,8 @@ export function createApiApp(options: CreateApiAppOptions = {}): ApiApp {
   };
 }
 
-export function startApiServer(port = Number(process.env.PORT ?? 4000)) {
-  const { store, storage } = createConfiguredStore();
-  const app = createApiApp({
-    store,
-    storage,
-  });
+export async function startApiServer(port = Number(process.env.PORT ?? 4000)) {
+  const app = await createDefaultApiApp();
   const server = createServer(async (request, response) => {
     const result = await app.handle(toRequest(request));
     result.headers.set('access-control-allow-origin', '*');
@@ -113,9 +118,9 @@ export function startApiServer(port = Number(process.env.PORT ?? 4000)) {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const port = Number(process.env.PORT ?? 4000);
-  const server = startApiServer(port);
-
-  server.on('listening', () => {
-    process.stdout.write(`Agent Studio API listening on http://localhost:${port}\n`);
+  startApiServer(port).then((server) => {
+    server.on('listening', () => {
+      process.stdout.write(`Agent Studio API listening on http://localhost:${port}\n`);
+    });
   });
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,9 +1,43 @@
-import type { OperationalContext, Replay, Run, StudioState, Workflow } from '@agent-studio/contracts';
-import { operationalContextSchema, replaySchema, runSchema, studioStateSchema, workflowSchema } from '@agent-studio/contracts';
+import type {
+  AgentDefinition,
+  ArtifactRecord,
+  EvaluationRecord,
+  ExecutionRecord,
+  InterventionRecord,
+  OperationalContext,
+  Replay,
+  ReleaseDecision,
+  Run,
+  RuntimeRegistration,
+  SpanRecord,
+  StudioState,
+  SystemDefinition,
+  TopologySnapshot,
+  Workflow,
+} from '@agent-studio/contracts';
+import {
+  agentDefinitionSchema,
+  artifactRecordSchema,
+  evaluationRecordSchema,
+  executionRecordSchema,
+  interventionRecordSchema,
+  metricSampleSchema,
+  operationalContextSchema,
+  replaySchema,
+  releaseDecisionSchema,
+  runSchema,
+  runtimeRegistrationSchema,
+  spanRecordSchema,
+  studioStateSchema,
+  systemDefinitionSchema,
+  topologySnapshotSchema,
+  workflowSchema,
+  type MetricSample,
+} from '@agent-studio/contracts';
 import { seededOperationalContexts, seededReplays } from '@agent-studio/demo';
 
+import { createSeededControlPlaneState } from './control-plane-seed.js';
 import {
-  cloneOperationalContext,
   cloneReplay,
   cloneRun,
   cloneStudioState,
@@ -12,12 +46,37 @@ import {
   type DemoStateResponse,
 } from './demo-state.js';
 
+function cloneRecord<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function sortByLabel<T extends { label?: string; name?: string }>(values: T[]) {
+  return [...values].sort((left, right) => {
+    const leftLabel = left.label ?? left.name ?? '';
+    const rightLabel = right.label ?? right.name ?? '';
+
+    return leftLabel.localeCompare(rightLabel);
+  });
+}
+
 export class ApiStore {
   private readonly workflows = new Map<string, Workflow>();
   private readonly runs = new Map<string, Run>();
   private readonly replays = new Map<string, Replay>();
   private readonly operationalContexts = new Map<string, OperationalContext>();
   private readonly studioStates = new Map<string, StudioState>();
+
+  private readonly runtimes = new Map<string, RuntimeRegistration>();
+  private readonly systems = new Map<string, SystemDefinition>();
+  private readonly agents = new Map<string, AgentDefinition>();
+  private readonly topologySnapshots = new Map<string, TopologySnapshot[]>();
+  private readonly executions = new Map<string, ExecutionRecord>();
+  private readonly spans = new Map<string, SpanRecord>();
+  private readonly artifacts = new Map<string, ArtifactRecord>();
+  private readonly metrics = new Map<string, MetricSample>();
+  private readonly interventions = new Map<string, InterventionRecord>();
+  private readonly evaluations = new Map<string, EvaluationRecord>();
+  private readonly releaseDecisions = new Map<string, ReleaseDecision>();
 
   constructor(seed = createSeededDemoState()) {
     seed.workflows.forEach((workflow) => this.workflows.set(workflow.workflowId, cloneWorkflow(workflow)));
@@ -33,15 +92,30 @@ export class ApiStore {
     });
 
     Object.values(seededOperationalContexts).forEach((context) => {
-      operationalContextSchema.parse(context);
-      this.operationalContexts.set(context.runId, cloneOperationalContext(context));
+      const parsed = operationalContextSchema.parse(context);
+      this.operationalContexts.set(parsed.runId ?? `${parsed.workflowId}:${parsed.generatedAt}`, cloneRecord(parsed));
     });
+
+    const controlPlaneSeed = createSeededControlPlaneState(seed);
+    controlPlaneSeed.runtimes.forEach((runtime) => this.runtimes.set(runtime.runtimeId, cloneRecord(runtime)));
+    controlPlaneSeed.systems.forEach((system) => this.systems.set(system.systemId, cloneRecord(system)));
+    controlPlaneSeed.agents.forEach((agent) => this.agents.set(agent.agentId, cloneRecord(agent)));
+    controlPlaneSeed.topologySnapshots.forEach((snapshot) => this.upsertTopologySnapshot(snapshot));
+    controlPlaneSeed.executions.forEach((execution) => this.executions.set(execution.executionId, cloneRecord(execution)));
+    controlPlaneSeed.spans.forEach((span) => this.spans.set(span.spanId, cloneRecord(span)));
+    controlPlaneSeed.artifacts.forEach((artifact) => this.artifacts.set(artifact.artifactId, cloneRecord(artifact)));
+    controlPlaneSeed.metrics.forEach((metric) => this.metrics.set(metric.sampleId, cloneRecord(metric)));
+    controlPlaneSeed.interventions.forEach((intervention) =>
+      this.interventions.set(intervention.interventionId, cloneRecord(intervention)),
+    );
+    controlPlaneSeed.evaluations.forEach((evaluation) => this.evaluations.set(evaluation.evaluationId, cloneRecord(evaluation)));
+    controlPlaneSeed.releaseDecisions.forEach((releaseDecision) =>
+      this.releaseDecisions.set(releaseDecision.releaseId, cloneRecord(releaseDecision)),
+    );
   }
 
   listWorkflows(): Workflow[] {
-    return [...this.workflows.values()]
-      .map((workflow) => cloneWorkflow(workflow))
-      .sort((left, right) => left.name.localeCompare(right.name));
+    return sortByLabel([...this.workflows.values()]).map((workflow) => cloneWorkflow(workflow));
   }
 
   getWorkflow(workflowId: string): Workflow | undefined {
@@ -94,7 +168,7 @@ export class ApiStore {
     this.replays.set(parsed.run.runId, cloneReplay(parsed));
 
     if (parsed.operationalContext?.runId) {
-      this.operationalContexts.set(parsed.operationalContext.runId, cloneOperationalContext(parsed.operationalContext));
+      this.operationalContexts.set(parsed.operationalContext.runId, cloneRecord(parsed.operationalContext));
     }
 
     if (parsed.studioState) {
@@ -107,21 +181,251 @@ export class ApiStore {
   getOperationalContext(runId: string): OperationalContext | undefined {
     const operationalContext = this.operationalContexts.get(runId);
 
-    return operationalContext ? cloneOperationalContext(operationalContext) : undefined;
+    return operationalContext ? cloneRecord(operationalContext) : undefined;
   }
 
   upsertOperationalContext(operationalContext: OperationalContext): OperationalContext {
     const parsed = operationalContextSchema.parse(operationalContext);
     const key = parsed.runId ?? `${parsed.workflowId}:${parsed.generatedAt}`;
-    this.operationalContexts.set(key, cloneOperationalContext(parsed));
+    this.operationalContexts.set(key, cloneRecord(parsed));
 
-    return cloneOperationalContext(parsed);
+    return cloneRecord(parsed);
   }
 
   getStudioState(workflowId: string): StudioState | undefined {
     const studioState = this.studioStates.get(workflowId);
 
     return studioState ? cloneStudioState(studioState) : undefined;
+  }
+
+  listRuntimes(): RuntimeRegistration[] {
+    return sortByLabel([...this.runtimes.values()]).map((runtime) => cloneRecord(runtime));
+  }
+
+  getRuntime(runtimeId: string): RuntimeRegistration | undefined {
+    const runtime = this.runtimes.get(runtimeId);
+
+    return runtime ? cloneRecord(runtime) : undefined;
+  }
+
+  upsertRuntime(runtime: RuntimeRegistration): RuntimeRegistration {
+    const parsed = runtimeRegistrationSchema.parse(runtime);
+    this.runtimes.set(parsed.runtimeId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertRuntimes(runtimes: RuntimeRegistration[]) {
+    return runtimes.map((runtime) => this.upsertRuntime(runtime));
+  }
+
+  listSystems(): SystemDefinition[] {
+    return sortByLabel([...this.systems.values()]).map((system) => cloneRecord(system));
+  }
+
+  getSystem(systemId: string): SystemDefinition | undefined {
+    const system = this.systems.get(systemId);
+
+    return system ? cloneRecord(system) : undefined;
+  }
+
+  upsertSystem(system: SystemDefinition): SystemDefinition {
+    const parsed = systemDefinitionSchema.parse(system);
+    this.systems.set(parsed.systemId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertSystems(systems: SystemDefinition[]) {
+    return systems.map((system) => this.upsertSystem(system));
+  }
+
+  listAgentsBySystem(systemId: string): AgentDefinition[] {
+    return sortByLabel([...this.agents.values()].filter((agent) => agent.systemId === systemId)).map((agent) => cloneRecord(agent));
+  }
+
+  getAgent(agentId: string): AgentDefinition | undefined {
+    const agent = this.agents.get(agentId);
+
+    return agent ? cloneRecord(agent) : undefined;
+  }
+
+  upsertAgent(agent: AgentDefinition): AgentDefinition {
+    const parsed = agentDefinitionSchema.parse(agent);
+    this.agents.set(parsed.agentId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertAgents(agents: AgentDefinition[]) {
+    return agents.map((agent) => this.upsertAgent(agent));
+  }
+
+  getLatestTopologySnapshot(systemId: string): TopologySnapshot | undefined {
+    const snapshots = this.topologySnapshots.get(systemId) ?? [];
+    const latest = [...snapshots].sort((left, right) => right.capturedAt.localeCompare(left.capturedAt))[0];
+
+    return latest ? cloneRecord(latest) : undefined;
+  }
+
+  upsertTopologySnapshot(snapshot: TopologySnapshot): TopologySnapshot {
+    const parsed = topologySnapshotSchema.parse(snapshot);
+    const current = this.topologySnapshots.get(parsed.systemId) ?? [];
+    const next = current.filter((item) => item.snapshotId !== parsed.snapshotId);
+    next.push(cloneRecord(parsed));
+    this.topologySnapshots.set(parsed.systemId, next);
+
+    return cloneRecord(parsed);
+  }
+
+  upsertTopologySnapshots(snapshots: TopologySnapshot[]) {
+    return snapshots.map((snapshot) => this.upsertTopologySnapshot(snapshot));
+  }
+
+  listExecutionsBySystem(systemId: string): ExecutionRecord[] {
+    return [...this.executions.values()]
+      .filter((execution) => execution.systemId === systemId)
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt))
+      .map((execution) => cloneRecord(execution));
+  }
+
+  getExecution(executionId: string): ExecutionRecord | undefined {
+    const execution = this.executions.get(executionId);
+
+    return execution ? cloneRecord(execution) : undefined;
+  }
+
+  upsertExecution(execution: ExecutionRecord): ExecutionRecord {
+    const parsed = executionRecordSchema.parse(execution);
+    this.executions.set(parsed.executionId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertExecutions(executions: ExecutionRecord[]) {
+    return executions.map((execution) => this.upsertExecution(execution));
+  }
+
+  listSpansByExecution(executionId: string): SpanRecord[] {
+    return [...this.spans.values()]
+      .filter((span) => span.executionId === executionId)
+      .sort((left, right) => left.startedAt.localeCompare(right.startedAt))
+      .map((span) => cloneRecord(span));
+  }
+
+  upsertSpan(span: SpanRecord): SpanRecord {
+    const parsed = spanRecordSchema.parse(span);
+    this.spans.set(parsed.spanId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertSpans(spans: SpanRecord[]) {
+    return spans.map((span) => this.upsertSpan(span));
+  }
+
+  listArtifactsByExecution(executionId: string): ArtifactRecord[] {
+    return [...this.artifacts.values()]
+      .filter((artifact) => artifact.executionId === executionId)
+      .map((artifact) => cloneRecord(artifact));
+  }
+
+  upsertArtifact(artifact: ArtifactRecord): ArtifactRecord {
+    const parsed = artifactRecordSchema.parse(artifact);
+    this.artifacts.set(parsed.artifactId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertArtifacts(artifacts: ArtifactRecord[]) {
+    return artifacts.map((artifact) => this.upsertArtifact(artifact));
+  }
+
+  listMetricsByScope(scopeType: string, scopeId: string): MetricSample[] {
+    return [...this.metrics.values()]
+      .filter((metric) => metric.scopeType === scopeType && metric.scopeId === scopeId)
+      .sort((left, right) => left.ts.localeCompare(right.ts))
+      .map((metric) => cloneRecord(metric));
+  }
+
+  upsertMetric(metric: MetricSample): MetricSample {
+    const parsed = metricSampleSchema.parse(metric);
+    this.metrics.set(parsed.sampleId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertMetrics(metrics: MetricSample[]) {
+    return metrics.map((metric) => this.upsertMetric(metric));
+  }
+
+  listInterventionsBySystem(systemId: string): InterventionRecord[] {
+    const agents = this.listAgentsBySystem(systemId);
+    const executions = this.listExecutionsBySystem(systemId);
+    const agentIds = new Set(agents.map((agent) => agent.agentId));
+    const traceIds = new Set(executions.map((execution) => execution.traceId));
+
+    return [...this.interventions.values()]
+      .filter((intervention) => {
+        if (intervention.targetScopeType === 'system' && intervention.targetScopeId === systemId) {
+          return true;
+        }
+
+        if (intervention.targetScopeType === 'agent' && agentIds.has(intervention.targetScopeId)) {
+          return true;
+        }
+
+        return intervention.relatedTraceId ? traceIds.has(intervention.relatedTraceId) : false;
+      })
+      .sort((left, right) => right.requestedAt.localeCompare(left.requestedAt))
+      .map((intervention) => cloneRecord(intervention));
+  }
+
+  upsertIntervention(intervention: InterventionRecord): InterventionRecord {
+    const parsed = interventionRecordSchema.parse(intervention);
+    this.interventions.set(parsed.interventionId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertInterventions(interventions: InterventionRecord[]) {
+    return interventions.map((intervention) => this.upsertIntervention(intervention));
+  }
+
+  listEvaluationsBySystem(systemId: string): EvaluationRecord[] {
+    return [...this.evaluations.values()]
+      .filter((evaluation) => evaluation.targetScopeType === 'system' && evaluation.targetScopeId === systemId)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .map((evaluation) => cloneRecord(evaluation));
+  }
+
+  upsertEvaluation(evaluation: EvaluationRecord): EvaluationRecord {
+    const parsed = evaluationRecordSchema.parse(evaluation);
+    this.evaluations.set(parsed.evaluationId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertEvaluations(evaluations: EvaluationRecord[]) {
+    return evaluations.map((evaluation) => this.upsertEvaluation(evaluation));
+  }
+
+  listReleaseDecisionsBySystem(systemId: string): ReleaseDecision[] {
+    return [...this.releaseDecisions.values()]
+      .filter((releaseDecision) => releaseDecision.systemId === systemId)
+      .sort((left, right) => right.requestedAt.localeCompare(left.requestedAt))
+      .map((releaseDecision) => cloneRecord(releaseDecision));
+  }
+
+  upsertReleaseDecision(releaseDecision: ReleaseDecision): ReleaseDecision {
+    const parsed = releaseDecisionSchema.parse(releaseDecision);
+    this.releaseDecisions.set(parsed.releaseId, cloneRecord(parsed));
+
+    return cloneRecord(parsed);
+  }
+
+  upsertReleaseDecisions(releaseDecisions: ReleaseDecision[]) {
+    return releaseDecisions.map((releaseDecision) => this.upsertReleaseDecision(releaseDecision));
   }
 
   private buildDemoWorkflowState(workflow: Workflow): DemoStateResponse['workflowStates'][string] | null {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -59,6 +59,33 @@ function sortByLabel<T extends { label?: string; name?: string }>(values: T[]) {
   });
 }
 
+export interface ApiStoreSnapshot {
+  workflows: Workflow[];
+  runs: Run[];
+  replays: Replay[];
+  operationalContexts: OperationalContext[];
+  studioStates: Array<{
+    workflowId: string;
+    studioState: StudioState;
+  }>;
+  runtimes: RuntimeRegistration[];
+  systems: SystemDefinition[];
+  agents: AgentDefinition[];
+  topologySnapshots: TopologySnapshot[];
+  executions: ExecutionRecord[];
+  spans: SpanRecord[];
+  artifacts: ArtifactRecord[];
+  metrics: MetricSample[];
+  interventions: InterventionRecord[];
+  evaluations: EvaluationRecord[];
+  releaseDecisions: ReleaseDecision[];
+}
+
+interface ApiStoreOptions {
+  snapshot?: ApiStoreSnapshot | null;
+  onChange?: (snapshot: ApiStoreSnapshot) => void;
+}
+
 export class ApiStore {
   private readonly workflows = new Map<string, Workflow>();
   private readonly runs = new Map<string, Run>();
@@ -77,8 +104,21 @@ export class ApiStore {
   private readonly interventions = new Map<string, InterventionRecord>();
   private readonly evaluations = new Map<string, EvaluationRecord>();
   private readonly releaseDecisions = new Map<string, ReleaseDecision>();
+  private readonly onChange?: (snapshot: ApiStoreSnapshot) => void;
+  private mutationDepth = 0;
 
-  constructor(seed = createSeededDemoState()) {
+  constructor(seed = createSeededDemoState(), options: ApiStoreOptions = {}) {
+    this.onChange = options.onChange;
+
+    if (options.snapshot) {
+      this.hydrateSnapshot(options.snapshot);
+      return;
+    }
+
+    this.hydrateSeed(seed);
+  }
+
+  private hydrateSeed(seed: ReturnType<typeof createSeededDemoState>) {
     seed.workflows.forEach((workflow) => this.workflows.set(workflow.workflowId, cloneWorkflow(workflow)));
 
     Object.values(seed.workflowStates).forEach((state) => {
@@ -114,6 +154,73 @@ export class ApiStore {
     );
   }
 
+  private hydrateSnapshot(snapshot: ApiStoreSnapshot) {
+    snapshot.workflows.forEach((workflow) => this.workflows.set(workflow.workflowId, cloneWorkflow(workflow)));
+    snapshot.runs.forEach((run) => this.runs.set(run.runId, cloneRun(run)));
+    snapshot.replays.forEach((replay) => this.replays.set(replay.run.runId, cloneReplay(replay)));
+    snapshot.operationalContexts.forEach((context) => {
+      const key = context.runId ?? `${context.workflowId}:${context.generatedAt}`;
+      this.operationalContexts.set(key, cloneRecord(context));
+    });
+    snapshot.studioStates.forEach((entry) => this.studioStates.set(entry.workflowId, cloneStudioState(entry.studioState)));
+    snapshot.runtimes.forEach((runtime) => this.runtimes.set(runtime.runtimeId, cloneRecord(runtime)));
+    snapshot.systems.forEach((system) => this.systems.set(system.systemId, cloneRecord(system)));
+    snapshot.agents.forEach((agent) => this.agents.set(agent.agentId, cloneRecord(agent)));
+    snapshot.topologySnapshots.forEach((snapshotEntry) => {
+      const current = this.topologySnapshots.get(snapshotEntry.systemId) ?? [];
+      current.push(cloneRecord(snapshotEntry));
+      this.topologySnapshots.set(snapshotEntry.systemId, current);
+    });
+    snapshot.executions.forEach((execution) => this.executions.set(execution.executionId, cloneRecord(execution)));
+    snapshot.spans.forEach((span) => this.spans.set(span.spanId, cloneRecord(span)));
+    snapshot.artifacts.forEach((artifact) => this.artifacts.set(artifact.artifactId, cloneRecord(artifact)));
+    snapshot.metrics.forEach((metric) => this.metrics.set(metric.sampleId, cloneRecord(metric)));
+    snapshot.interventions.forEach((intervention) =>
+      this.interventions.set(intervention.interventionId, cloneRecord(intervention)),
+    );
+    snapshot.evaluations.forEach((evaluation) => this.evaluations.set(evaluation.evaluationId, cloneRecord(evaluation)));
+    snapshot.releaseDecisions.forEach((releaseDecision) =>
+      this.releaseDecisions.set(releaseDecision.releaseId, cloneRecord(releaseDecision)),
+    );
+  }
+
+  private runMutation<T>(operation: () => T): T {
+    this.mutationDepth += 1;
+
+    try {
+      return operation();
+    } finally {
+      this.mutationDepth -= 1;
+      if (this.mutationDepth === 0) {
+        this.onChange?.(this.buildSnapshot());
+      }
+    }
+  }
+
+  buildSnapshot(): ApiStoreSnapshot {
+    return {
+      workflows: this.listWorkflows(),
+      runs: [...this.runs.values()].map((run) => cloneRun(run)),
+      replays: [...this.replays.values()].map((replay) => cloneReplay(replay)),
+      operationalContexts: [...this.operationalContexts.values()].map((context) => cloneRecord(context)),
+      studioStates: [...this.studioStates.entries()].map(([workflowId, studioState]) => ({
+        workflowId,
+        studioState: cloneStudioState(studioState),
+      })),
+      runtimes: this.listRuntimes(),
+      systems: this.listSystems(),
+      agents: [...this.agents.values()].map((agent) => cloneRecord(agent)),
+      topologySnapshots: [...this.topologySnapshots.values()].flatMap((snapshots) => snapshots.map((snapshot) => cloneRecord(snapshot))),
+      executions: [...this.executions.values()].map((execution) => cloneRecord(execution)),
+      spans: [...this.spans.values()].map((span) => cloneRecord(span)),
+      artifacts: [...this.artifacts.values()].map((artifact) => cloneRecord(artifact)),
+      metrics: [...this.metrics.values()].map((metric) => cloneRecord(metric)),
+      interventions: [...this.interventions.values()].map((intervention) => cloneRecord(intervention)),
+      evaluations: [...this.evaluations.values()].map((evaluation) => cloneRecord(evaluation)),
+      releaseDecisions: [...this.releaseDecisions.values()].map((releaseDecision) => cloneRecord(releaseDecision)),
+    };
+  }
+
   listWorkflows(): Workflow[] {
     return sortByLabel([...this.workflows.values()]).map((workflow) => cloneWorkflow(workflow));
   }
@@ -125,14 +232,16 @@ export class ApiStore {
   }
 
   upsertWorkflow(workflow: Workflow): Workflow {
-    const parsed = workflowSchema.parse(workflow);
-    this.workflows.set(parsed.workflowId, cloneWorkflow(parsed));
+    return this.runMutation(() => {
+      const parsed = workflowSchema.parse(workflow);
+      this.workflows.set(parsed.workflowId, cloneWorkflow(parsed));
 
-    if (!this.studioStates.has(parsed.workflowId)) {
-      this.studioStates.set(parsed.workflowId, studioStateSchema.parse({}));
-    }
+      if (!this.studioStates.has(parsed.workflowId)) {
+        this.studioStates.set(parsed.workflowId, studioStateSchema.parse({}));
+      }
 
-    return cloneWorkflow(parsed);
+      return cloneWorkflow(parsed);
+    });
   }
 
   listRunsByWorkflow(workflowId: string): Run[] {
@@ -149,10 +258,12 @@ export class ApiStore {
   }
 
   upsertRun(run: Run): Run {
-    const parsed = runSchema.parse(run);
-    this.runs.set(parsed.runId, cloneRun(parsed));
+    return this.runMutation(() => {
+      const parsed = runSchema.parse(run);
+      this.runs.set(parsed.runId, cloneRun(parsed));
 
-    return cloneRun(parsed);
+      return cloneRun(parsed);
+    });
   }
 
   getReplay(runId: string): Replay | undefined {
@@ -162,20 +273,22 @@ export class ApiStore {
   }
 
   upsertReplay(replay: Replay): Replay {
-    const parsed = replaySchema.parse(replay);
-    this.workflows.set(parsed.workflow.workflowId, cloneWorkflow(parsed.workflow));
-    this.runs.set(parsed.run.runId, cloneRun(parsed.run));
-    this.replays.set(parsed.run.runId, cloneReplay(parsed));
+    return this.runMutation(() => {
+      const parsed = replaySchema.parse(replay);
+      this.workflows.set(parsed.workflow.workflowId, cloneWorkflow(parsed.workflow));
+      this.runs.set(parsed.run.runId, cloneRun(parsed.run));
+      this.replays.set(parsed.run.runId, cloneReplay(parsed));
 
-    if (parsed.operationalContext?.runId) {
-      this.operationalContexts.set(parsed.operationalContext.runId, cloneRecord(parsed.operationalContext));
-    }
+      if (parsed.operationalContext?.runId) {
+        this.operationalContexts.set(parsed.operationalContext.runId, cloneRecord(parsed.operationalContext));
+      }
 
-    if (parsed.studioState) {
-      this.studioStates.set(parsed.workflow.workflowId, cloneStudioState(parsed.studioState));
-    }
+      if (parsed.studioState) {
+        this.studioStates.set(parsed.workflow.workflowId, cloneStudioState(parsed.studioState));
+      }
 
-    return cloneReplay(parsed);
+      return cloneReplay(parsed);
+    });
   }
 
   getOperationalContext(runId: string): OperationalContext | undefined {
@@ -185,11 +298,13 @@ export class ApiStore {
   }
 
   upsertOperationalContext(operationalContext: OperationalContext): OperationalContext {
-    const parsed = operationalContextSchema.parse(operationalContext);
-    const key = parsed.runId ?? `${parsed.workflowId}:${parsed.generatedAt}`;
-    this.operationalContexts.set(key, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = operationalContextSchema.parse(operationalContext);
+      const key = parsed.runId ?? `${parsed.workflowId}:${parsed.generatedAt}`;
+      this.operationalContexts.set(key, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   getStudioState(workflowId: string): StudioState | undefined {
@@ -209,14 +324,16 @@ export class ApiStore {
   }
 
   upsertRuntime(runtime: RuntimeRegistration): RuntimeRegistration {
-    const parsed = runtimeRegistrationSchema.parse(runtime);
-    this.runtimes.set(parsed.runtimeId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = runtimeRegistrationSchema.parse(runtime);
+      this.runtimes.set(parsed.runtimeId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertRuntimes(runtimes: RuntimeRegistration[]) {
-    return runtimes.map((runtime) => this.upsertRuntime(runtime));
+    return this.runMutation(() => runtimes.map((runtime) => this.upsertRuntime(runtime)));
   }
 
   listSystems(): SystemDefinition[] {
@@ -230,14 +347,16 @@ export class ApiStore {
   }
 
   upsertSystem(system: SystemDefinition): SystemDefinition {
-    const parsed = systemDefinitionSchema.parse(system);
-    this.systems.set(parsed.systemId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = systemDefinitionSchema.parse(system);
+      this.systems.set(parsed.systemId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertSystems(systems: SystemDefinition[]) {
-    return systems.map((system) => this.upsertSystem(system));
+    return this.runMutation(() => systems.map((system) => this.upsertSystem(system)));
   }
 
   listAgentsBySystem(systemId: string): AgentDefinition[] {
@@ -251,14 +370,16 @@ export class ApiStore {
   }
 
   upsertAgent(agent: AgentDefinition): AgentDefinition {
-    const parsed = agentDefinitionSchema.parse(agent);
-    this.agents.set(parsed.agentId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = agentDefinitionSchema.parse(agent);
+      this.agents.set(parsed.agentId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertAgents(agents: AgentDefinition[]) {
-    return agents.map((agent) => this.upsertAgent(agent));
+    return this.runMutation(() => agents.map((agent) => this.upsertAgent(agent)));
   }
 
   getLatestTopologySnapshot(systemId: string): TopologySnapshot | undefined {
@@ -269,17 +390,19 @@ export class ApiStore {
   }
 
   upsertTopologySnapshot(snapshot: TopologySnapshot): TopologySnapshot {
-    const parsed = topologySnapshotSchema.parse(snapshot);
-    const current = this.topologySnapshots.get(parsed.systemId) ?? [];
-    const next = current.filter((item) => item.snapshotId !== parsed.snapshotId);
-    next.push(cloneRecord(parsed));
-    this.topologySnapshots.set(parsed.systemId, next);
+    return this.runMutation(() => {
+      const parsed = topologySnapshotSchema.parse(snapshot);
+      const current = this.topologySnapshots.get(parsed.systemId) ?? [];
+      const next = current.filter((item) => item.snapshotId !== parsed.snapshotId);
+      next.push(cloneRecord(parsed));
+      this.topologySnapshots.set(parsed.systemId, next);
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertTopologySnapshots(snapshots: TopologySnapshot[]) {
-    return snapshots.map((snapshot) => this.upsertTopologySnapshot(snapshot));
+    return this.runMutation(() => snapshots.map((snapshot) => this.upsertTopologySnapshot(snapshot)));
   }
 
   listExecutionsBySystem(systemId: string): ExecutionRecord[] {
@@ -296,14 +419,16 @@ export class ApiStore {
   }
 
   upsertExecution(execution: ExecutionRecord): ExecutionRecord {
-    const parsed = executionRecordSchema.parse(execution);
-    this.executions.set(parsed.executionId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = executionRecordSchema.parse(execution);
+      this.executions.set(parsed.executionId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertExecutions(executions: ExecutionRecord[]) {
-    return executions.map((execution) => this.upsertExecution(execution));
+    return this.runMutation(() => executions.map((execution) => this.upsertExecution(execution)));
   }
 
   listSpansByExecution(executionId: string): SpanRecord[] {
@@ -314,14 +439,16 @@ export class ApiStore {
   }
 
   upsertSpan(span: SpanRecord): SpanRecord {
-    const parsed = spanRecordSchema.parse(span);
-    this.spans.set(parsed.spanId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = spanRecordSchema.parse(span);
+      this.spans.set(parsed.spanId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertSpans(spans: SpanRecord[]) {
-    return spans.map((span) => this.upsertSpan(span));
+    return this.runMutation(() => spans.map((span) => this.upsertSpan(span)));
   }
 
   listArtifactsByExecution(executionId: string): ArtifactRecord[] {
@@ -331,14 +458,16 @@ export class ApiStore {
   }
 
   upsertArtifact(artifact: ArtifactRecord): ArtifactRecord {
-    const parsed = artifactRecordSchema.parse(artifact);
-    this.artifacts.set(parsed.artifactId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = artifactRecordSchema.parse(artifact);
+      this.artifacts.set(parsed.artifactId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertArtifacts(artifacts: ArtifactRecord[]) {
-    return artifacts.map((artifact) => this.upsertArtifact(artifact));
+    return this.runMutation(() => artifacts.map((artifact) => this.upsertArtifact(artifact)));
   }
 
   listMetricsByScope(scopeType: string, scopeId: string): MetricSample[] {
@@ -349,14 +478,16 @@ export class ApiStore {
   }
 
   upsertMetric(metric: MetricSample): MetricSample {
-    const parsed = metricSampleSchema.parse(metric);
-    this.metrics.set(parsed.sampleId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = metricSampleSchema.parse(metric);
+      this.metrics.set(parsed.sampleId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertMetrics(metrics: MetricSample[]) {
-    return metrics.map((metric) => this.upsertMetric(metric));
+    return this.runMutation(() => metrics.map((metric) => this.upsertMetric(metric)));
   }
 
   listInterventionsBySystem(systemId: string): InterventionRecord[] {
@@ -382,14 +513,16 @@ export class ApiStore {
   }
 
   upsertIntervention(intervention: InterventionRecord): InterventionRecord {
-    const parsed = interventionRecordSchema.parse(intervention);
-    this.interventions.set(parsed.interventionId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = interventionRecordSchema.parse(intervention);
+      this.interventions.set(parsed.interventionId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertInterventions(interventions: InterventionRecord[]) {
-    return interventions.map((intervention) => this.upsertIntervention(intervention));
+    return this.runMutation(() => interventions.map((intervention) => this.upsertIntervention(intervention)));
   }
 
   listEvaluationsBySystem(systemId: string): EvaluationRecord[] {
@@ -400,14 +533,16 @@ export class ApiStore {
   }
 
   upsertEvaluation(evaluation: EvaluationRecord): EvaluationRecord {
-    const parsed = evaluationRecordSchema.parse(evaluation);
-    this.evaluations.set(parsed.evaluationId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = evaluationRecordSchema.parse(evaluation);
+      this.evaluations.set(parsed.evaluationId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertEvaluations(evaluations: EvaluationRecord[]) {
-    return evaluations.map((evaluation) => this.upsertEvaluation(evaluation));
+    return this.runMutation(() => evaluations.map((evaluation) => this.upsertEvaluation(evaluation)));
   }
 
   listReleaseDecisionsBySystem(systemId: string): ReleaseDecision[] {
@@ -418,14 +553,16 @@ export class ApiStore {
   }
 
   upsertReleaseDecision(releaseDecision: ReleaseDecision): ReleaseDecision {
-    const parsed = releaseDecisionSchema.parse(releaseDecision);
-    this.releaseDecisions.set(parsed.releaseId, cloneRecord(parsed));
+    return this.runMutation(() => {
+      const parsed = releaseDecisionSchema.parse(releaseDecision);
+      this.releaseDecisions.set(parsed.releaseId, cloneRecord(parsed));
 
-    return cloneRecord(parsed);
+      return cloneRecord(parsed);
+    });
   }
 
   upsertReleaseDecisions(releaseDecisions: ReleaseDecision[]) {
-    return releaseDecisions.map((releaseDecision) => this.upsertReleaseDecision(releaseDecision));
+    return this.runMutation(() => releaseDecisions.map((releaseDecision) => this.upsertReleaseDecision(releaseDecision)));
   }
 
   private buildDemoWorkflowState(workflow: Workflow): DemoStateResponse['workflowStates'][string] | null {

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -83,7 +83,7 @@ export interface ApiStoreSnapshot {
 
 interface ApiStoreOptions {
   snapshot?: ApiStoreSnapshot | null;
-  onChange?: (snapshot: ApiStoreSnapshot) => void;
+  onChange?: (snapshot: ApiStoreSnapshot) => void | Promise<void>;
 }
 
 export class ApiStore {
@@ -104,8 +104,9 @@ export class ApiStore {
   private readonly interventions = new Map<string, InterventionRecord>();
   private readonly evaluations = new Map<string, EvaluationRecord>();
   private readonly releaseDecisions = new Map<string, ReleaseDecision>();
-  private readonly onChange?: (snapshot: ApiStoreSnapshot) => void;
+  private readonly onChange?: (snapshot: ApiStoreSnapshot) => void | Promise<void>;
   private mutationDepth = 0;
+  private pendingPersistence = Promise.resolve();
 
   constructor(seed = createSeededDemoState(), options: ApiStoreOptions = {}) {
     this.onChange = options.onChange;
@@ -192,9 +193,18 @@ export class ApiStore {
     } finally {
       this.mutationDepth -= 1;
       if (this.mutationDepth === 0) {
-        this.onChange?.(this.buildSnapshot());
+        const maybePersist = this.onChange?.(this.buildSnapshot());
+
+        if (maybePersist && typeof (maybePersist as Promise<void>).then === 'function') {
+          const task = Promise.resolve(maybePersist).catch(() => undefined);
+          this.pendingPersistence = this.pendingPersistence.then(() => task);
+        }
       }
     }
+  }
+
+  flushPendingPersistence() {
+    return this.pendingPersistence;
   }
 
   buildSnapshot(): ApiStoreSnapshot {

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -1,11 +1,13 @@
 import { vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+import type { ControlPlaneState } from './control-plane';
 import type { DemoState } from './demo';
 import { App } from './App';
 
-const { loadDemoStateMock } = vi.hoisted(() => ({
+const { loadDemoStateMock, loadControlPlaneStateMock } = vi.hoisted(() => ({
   loadDemoStateMock: vi.fn(),
+  loadControlPlaneStateMock: vi.fn(),
 }));
 
 const demoStateFixture: DemoState = {
@@ -179,13 +181,56 @@ const demoStateFixture: DemoState = {
   },
 };
 
+const controlPlaneFixture: ControlPlaneState = {
+  runtimes: [
+    {
+      runtimeId: 'runtime_demo_seeded',
+      kind: 'demo',
+      adapterId: 'seeded-demo',
+      label: 'Seeded demo runtime',
+    },
+  ],
+  systems: [
+    {
+      system: {
+        systemId: 'system_workflow_ops_brief',
+        workspaceId: 'workspace_demo',
+        name: 'Weekly Operations Brief',
+        runtimeIds: ['runtime_demo_seeded'],
+        metadata: {
+          workflowId: 'workflow_ops_brief',
+        },
+      },
+      agents: [],
+      topology: null,
+      executions: [],
+      executionSpans: {},
+      executionMetrics: {},
+      interventions: [],
+      evaluations: [],
+      releases: [],
+    },
+  ],
+  systemsByWorkflowId: {},
+};
+
 vi.mock('./demo', () => ({
   loadDemoState: loadDemoStateMock,
+}));
+
+vi.mock('./control-plane', () => ({
+  loadControlPlaneState: loadControlPlaneStateMock,
 }));
 
 describe('App shell', () => {
   beforeEach(() => {
     loadDemoStateMock.mockResolvedValue(demoStateFixture);
+    loadControlPlaneStateMock.mockResolvedValue({
+      ...controlPlaneFixture,
+      systemsByWorkflowId: {
+        workflow_ops_brief: controlPlaneFixture.systems[0],
+      },
+    });
   });
 
   it('renders the seeded demo control loop', async () => {

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import type { ControlPlaneState } from './control-plane';
 import type { DemoState } from './demo';
@@ -559,13 +559,21 @@ describe('App shell', () => {
     render(<App />);
 
     expect(await screen.findByLabelText(/^runtime$/i)).toHaveValue('runtime_imported');
+    expect(screen.getByRole('heading', { level: 2, name: /time-windowed system view/i })).toBeInTheDocument();
     expect(screen.getByText(/fleet analytics/i)).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { level: 2, name: /pressure, failures, and recent activity/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /what changed in this system/i })).toBeInTheDocument();
-    expect(screen.getByText(/recent failures and holds/i)).toBeInTheDocument();
+    expect(screen.getByText(/window posture/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /releases/i })).toBeInTheDocument();
     expect(screen.getByText(/history persistent/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^24h$/i }));
+    expect(screen.getAllByText(/24h window/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/1 tracked execution/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^failures$/i }));
+    expect(screen.getByText(/1 visible · 24h/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -214,6 +214,247 @@ const controlPlaneFixture: ControlPlaneState = {
   systemsByWorkflowId: {},
 };
 
+const importedSystemState: ControlPlaneState['systems'][number] = {
+  system: {
+    systemId: 'system_imported',
+    workspaceId: 'workspace_imported',
+    name: 'Imported support triage',
+    description: 'A bring-your-own agent system imported through the control-plane ingest path.',
+    runtimeIds: ['runtime_imported'],
+    primaryRuntimeId: 'runtime_imported',
+    status: 'active',
+  },
+  agents: [
+    {
+      agentId: 'agent_triage_manager',
+      systemId: 'system_imported',
+      runtimeId: 'runtime_imported',
+      label: 'Triage manager',
+      kind: 'coordinator',
+      role: 'manager',
+      status: 'active',
+    },
+    {
+      agentId: 'agent_support_reviewer',
+      systemId: 'system_imported',
+      runtimeId: 'runtime_imported',
+      label: 'Support reviewer',
+      kind: 'specialist',
+      role: 'reviewer',
+      status: 'active',
+    },
+  ],
+  topology: {
+    snapshotId: 'topology_imported',
+    systemId: 'system_imported',
+    capturedAt: '2026-04-22T12:00:00.000Z',
+    nodes: [
+      {
+        nodeId: 'node_manager',
+        agentId: 'agent_triage_manager',
+        runtimeId: 'runtime_imported',
+        label: 'Triage manager',
+        kind: 'coordinator',
+        role: 'manager',
+      },
+      {
+        nodeId: 'node_reviewer',
+        agentId: 'agent_support_reviewer',
+        runtimeId: 'runtime_imported',
+        label: 'Support reviewer',
+        kind: 'specialist',
+        role: 'reviewer',
+      },
+    ],
+    edges: [
+      {
+        edgeId: 'edge_manager_reviewer',
+        sourceNodeId: 'node_manager',
+        targetNodeId: 'node_reviewer',
+        kind: 'handoff',
+      },
+    ],
+  },
+  executions: [
+    {
+      executionId: 'exec_imported_latest',
+      systemId: 'system_imported',
+      runtimeId: 'runtime_imported',
+      traceId: 'trace_imported_latest',
+      status: 'running',
+      startedAt: '2026-04-22T12:05:00.000Z',
+      finishedAt: '2026-04-22T12:11:00.000Z',
+      runId: 'run_imported_latest',
+      metadata: {
+        experimentLabel: 'Imported live execution',
+      },
+    },
+    {
+      executionId: 'exec_imported_baseline',
+      systemId: 'system_imported',
+      runtimeId: 'runtime_imported',
+      traceId: 'trace_imported_baseline',
+      status: 'succeeded',
+      startedAt: '2026-04-21T12:05:00.000Z',
+      finishedAt: '2026-04-21T12:10:00.000Z',
+      runId: 'run_imported_baseline',
+      metadata: {
+        experimentLabel: 'Imported baseline execution',
+      },
+    },
+  ],
+  executionSpans: {
+    exec_imported_latest: [
+      {
+        spanId: 'span_imported_capture',
+        traceId: 'trace_imported_latest',
+        executionId: 'exec_imported_latest',
+        nodeId: 'node_manager',
+        agentId: 'agent_triage_manager',
+        name: 'Collect incoming tickets',
+        kind: 'capture',
+        status: 'succeeded',
+        startedAt: '2026-04-22T12:05:00.000Z',
+        finishedAt: '2026-04-22T12:06:00.000Z',
+        summary: 'Collected the current support queue.',
+        usage: {
+          credits: 4,
+          durationMs: 60000,
+        },
+      },
+      {
+        spanId: 'span_imported_review',
+        traceId: 'trace_imported_latest',
+        executionId: 'exec_imported_latest',
+        parentSpanId: 'span_imported_capture',
+        nodeId: 'node_reviewer',
+        agentId: 'agent_support_reviewer',
+        name: 'Review escalation batch',
+        kind: 'review',
+        status: 'failed',
+        startedAt: '2026-04-22T12:06:10.000Z',
+        finishedAt: '2026-04-22T12:11:00.000Z',
+        summary: 'Escalation review tripped the response policy.',
+        usage: {
+          credits: 8,
+          durationMs: 290000,
+        },
+      },
+    ],
+    exec_imported_baseline: [
+      {
+        spanId: 'span_imported_baseline_capture',
+        traceId: 'trace_imported_baseline',
+        executionId: 'exec_imported_baseline',
+        nodeId: 'node_manager',
+        agentId: 'agent_triage_manager',
+        name: 'Collect incoming tickets',
+        kind: 'capture',
+        status: 'succeeded',
+        startedAt: '2026-04-21T12:05:00.000Z',
+        finishedAt: '2026-04-21T12:06:00.000Z',
+        summary: 'Collected the previous support queue cleanly.',
+        usage: {
+          credits: 3,
+          durationMs: 60000,
+        },
+      },
+    ],
+  },
+  executionMetrics: {
+    exec_imported_latest: [
+      {
+        sampleId: 'metric_imported_latest_credits',
+        metric: 'credits.actual',
+        unit: 'credits',
+        value: 12,
+        ts: '2026-04-22T12:11:00.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_imported_latest',
+      },
+      {
+        sampleId: 'metric_imported_latest_duration',
+        metric: 'duration.ms',
+        unit: 'ms',
+        value: 360000,
+        ts: '2026-04-22T12:11:00.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_imported_latest',
+      },
+    ],
+    exec_imported_baseline: [
+      {
+        sampleId: 'metric_imported_baseline_credits',
+        metric: 'credits.actual',
+        unit: 'credits',
+        value: 7,
+        ts: '2026-04-21T12:10:00.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_imported_baseline',
+      },
+      {
+        sampleId: 'metric_imported_baseline_duration',
+        metric: 'duration.ms',
+        unit: 'ms',
+        value: 300000,
+        ts: '2026-04-21T12:10:00.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_imported_baseline',
+      },
+    ],
+  },
+  interventions: [
+    {
+      interventionId: 'intervention_imported_review',
+      targetScopeType: 'agent',
+      targetScopeId: 'agent_support_reviewer',
+      actor: 'operator',
+      action: 'directive.review',
+      reason: 'Keep the imported reviewer under tighter scrutiny until the escalation path is stable.',
+      requestedAt: '2026-04-22T12:12:00.000Z',
+      appliedAt: '2026-04-22T12:12:00.000Z',
+      status: 'applied',
+      configPatch: {
+        phases: ['note'],
+      },
+    },
+  ],
+  evaluations: [
+    {
+      evaluationId: 'evaluation_imported',
+      targetScopeType: 'system',
+      targetScopeId: 'system_imported',
+      baselineRefs: ['run_imported_baseline'],
+      candidateRefs: ['run_imported_latest'],
+      verdict: 'hold',
+      createdAt: '2026-04-22T12:13:00.000Z',
+      summary: 'Hold the imported release until the escalation review path clears.',
+      metricDeltas: [
+        {
+          metric: 'credits.actual',
+          unit: 'credits',
+          baselineValue: 7,
+          candidateValue: 12,
+          delta: 5,
+        },
+      ],
+    },
+  ],
+  releases: [
+    {
+      releaseId: 'release_imported',
+      systemId: 'system_imported',
+      candidateRef: 'run_imported_latest',
+      baselineRef: 'run_imported_baseline',
+      decision: 'hold',
+      requestedAt: '2026-04-22T12:14:00.000Z',
+      appliedAt: '2026-04-22T12:14:00.000Z',
+      status: 'applied',
+      summary: 'Hold the imported release until the reviewer stops tripping the escalation policy.',
+    },
+  ],
+};
+
 vi.mock('./demo', () => ({
   loadDemoState: loadDemoStateMock,
 }));
@@ -229,6 +470,7 @@ vi.mock('./control-plane', async (importOriginal) => {
 
 describe('App shell', () => {
   beforeEach(() => {
+    window.history.pushState({}, '', '/');
     loadDemoStateMock.mockResolvedValue(demoStateFixture);
     loadControlPlaneStateMock.mockResolvedValue({
       ...controlPlaneFixture,
@@ -253,5 +495,32 @@ describe('App shell', () => {
     expect(screen.getAllByRole('heading', { level: 3, name: /weekly operations brief/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/guardrailed candidate/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/promoted the tighter fan-out plan/i)).toBeInTheDocument();
+  });
+
+  it('renders a live room for an imported system without a seeded workflow mapping', async () => {
+    window.history.pushState({}, '', '/systems/system_imported/live');
+    loadControlPlaneStateMock.mockResolvedValue({
+      ...controlPlaneFixture,
+      runtimes: [
+        ...controlPlaneFixture.runtimes,
+        {
+          runtimeId: 'runtime_imported',
+          kind: 'custom',
+          adapterId: 'custom-ingest',
+          label: 'Imported runtime',
+        },
+      ],
+      systems: [controlPlaneFixture.systems[0], importedSystemState],
+      systemsByWorkflowId: {
+        workflow_ops_brief: controlPlaneFixture.systems[0],
+      },
+    });
+
+    render(<App />);
+
+    expect(await screen.findByLabelText(/^system$/i)).toHaveValue('system_imported');
+    expect(screen.getByRole('heading', { name: /working agents and command flow/i })).toBeInTheDocument();
+    expect(screen.getByText(/this topology now reads the control-plane model directly/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no seeded room projection/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -241,7 +241,7 @@ describe('App shell', () => {
   it('renders the seeded demo control loop', async () => {
     render(<App />);
 
-    expect(await screen.findByLabelText(/^runtime$/i)).toHaveValue('demo');
+    expect(await screen.findByLabelText(/^runtime$/i)).toHaveValue('runtime_demo_seeded');
     expect(screen.getByLabelText(/^system$/i)).toHaveDisplayValue(/weekly operations brief/i);
     expect(screen.getByRole('heading', { level: 1, name: /agent studio/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /registered systems/i })).toBeInTheDocument();

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -559,6 +559,8 @@ describe('App shell', () => {
     render(<App />);
 
     expect(await screen.findByLabelText(/^runtime$/i)).toHaveValue('runtime_imported');
+    expect(screen.getByRole('heading', { level: 2, name: /cross-system pressure and release watch/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/filter systems/i)).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /time-windowed system view/i })).toBeInTheDocument();
     expect(screen.getByText(/fleet analytics/i)).toBeInTheDocument();
     expect(

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -218,9 +218,14 @@ vi.mock('./demo', () => ({
   loadDemoState: loadDemoStateMock,
 }));
 
-vi.mock('./control-plane', () => ({
-  loadControlPlaneState: loadControlPlaneStateMock,
-}));
+vi.mock('./control-plane', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./control-plane')>();
+
+  return {
+    ...actual,
+    loadControlPlaneState: loadControlPlaneStateMock,
+  };
+});
 
 describe('App shell', () => {
   beforeEach(() => {
@@ -237,14 +242,15 @@ describe('App shell', () => {
     render(<App />);
 
     expect(await screen.findByLabelText(/^runtime$/i)).toHaveValue('demo');
+    expect(screen.getByLabelText(/^system$/i)).toHaveDisplayValue(/weekly operations brief/i);
     expect(screen.getByRole('heading', { level: 1, name: /agent studio/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/^workflow$/i)).toHaveDisplayValue(/weekly operations brief/i);
+    expect(screen.getByRole('heading', { level: 2, name: /registered systems/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /^live, replay, optimize$/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /how agent studio works/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /connect your own multi-agent system/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /^live$/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /^replay$/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /^optimize$/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: /weekly operations brief/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3, name: /weekly operations brief/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/guardrailed candidate/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/promoted the tighter fan-out plan/i)).toBeInTheDocument();
   });

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -529,4 +529,43 @@ describe('App shell', () => {
     expect(screen.getByText(/this topology now reads the control-plane model directly/i)).toBeInTheDocument();
     expect(screen.queryByText(/no seeded room projection/i)).not.toBeInTheDocument();
   });
+
+  it('renders fleet analytics and recent history for an imported system overview', async () => {
+    window.history.pushState({}, '', '/systems/system_imported');
+    loadControlPlaneStateMock.mockResolvedValue({
+      ...controlPlaneFixture,
+      runtimes: [
+        ...controlPlaneFixture.runtimes,
+        {
+          runtimeId: 'runtime_imported',
+          kind: 'custom',
+          adapterId: 'custom-ingest',
+          label: 'Imported runtime',
+        },
+      ],
+      systems: [controlPlaneFixture.systems[0], importedSystemState],
+      systemsByWorkflowId: {
+        workflow_ops_brief: controlPlaneFixture.systems[0],
+      },
+      storage: {
+        mode: 'blob',
+        persistenceEnabled: true,
+        filePath: null,
+        blobPath: 'control-plane/store.json',
+        detail: 'Persistent hosted Vercel Blob store for public imports, fleet history, and control-plane state.',
+      },
+    });
+
+    render(<App />);
+
+    expect(await screen.findByLabelText(/^runtime$/i)).toHaveValue('runtime_imported');
+    expect(screen.getByText(/fleet analytics/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /pressure, failures, and recent activity/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /what changed in this system/i })).toBeInTheDocument();
+    expect(screen.getByText(/recent failures and holds/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /releases/i })).toBeInTheDocument();
+    expect(screen.getByText(/history persistent/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -182,6 +182,12 @@ const demoStateFixture: DemoState = {
 };
 
 const controlPlaneFixture: ControlPlaneState = {
+  storage: {
+    mode: 'memory',
+    persistenceEnabled: false,
+    filePath: null,
+    detail: 'Ephemeral in-memory demo store.',
+  },
   runtimes: [
     {
       runtimeId: 'runtime_demo_seeded',

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -507,7 +507,7 @@ export function App() {
             title={ROOM_COPY.replay.title}
             body={ROOM_COPY.replay.body}
             items={ROOM_COPY.replay.items}
-            advanced={<ReplayAdvancedPanel replay={selectedWorkflowState.replay.replay} />}
+            advanced={<ReplayAdvancedPanel replay={selectedWorkflowState.replay.replay} controlPlane={selectedControlPlaneSystem} />}
             showAdvanced={advancedOpen.replay}
             onToggleAdvanced={() => toggleAdvanced('replay')}
             advancedEyebrow={ROOM_COPY.replay.advancedEyebrow}
@@ -516,7 +516,11 @@ export function App() {
             openLabel={ROOM_COPY.replay.openLabel}
             closeLabel={ROOM_COPY.replay.closeLabel}
           >
-            <ReplayPanel replay={selectedWorkflowState.replay.replay} baselineRun={selectedWorkflowState.replay.baselineRun} />
+            <ReplayPanel
+              replay={selectedWorkflowState.replay.replay}
+              baselineRun={selectedWorkflowState.replay.baselineRun}
+              controlPlane={selectedControlPlaneSystem}
+            />
           </RoomShell>
         ) : null}
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -712,6 +712,7 @@ export function App() {
             sortedSystems={sortedSystems}
             selectedSystem={selectedControlPlaneSystem}
             selectedWorkflowState={selectedWorkflowState}
+            storage={controlPlaneState?.storage ?? null}
             selectedAgentId={selectedAgentId || null}
             onSelectSystem={handleSystemChange}
             onSelectAgent={setSelectedAgentId}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -13,6 +13,16 @@ import { ReplayPanel } from '../features/replay/ReplayPanel';
 
 type RoomId = 'live' | 'replay' | 'optimize';
 
+type ControlLoopCue = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  primaryLabel: string;
+  onPrimary: () => void;
+  secondaryLabel?: string;
+  onSecondary?: () => void;
+};
+
 const ROOM_LABELS: Record<
   RoomId,
   {
@@ -207,6 +217,37 @@ export function App() {
     ((candidateRun.durationMs ?? 0) - (selectedWorkflowState.optimize.baselineRun.durationMs ?? 0)) / 1000,
   );
   const selectedRuntime = demoState.runtimeOptions.find((option) => option.id === runtimeId);
+
+  const controlLoopCue: ControlLoopCue =
+    selectedRoom === 'live'
+      ? {
+          eyebrow: 'Control loop',
+          title: 'Next: open Replay',
+          body: `${replayRun.experimentLabel} is the clearest weak run in the loop. Use Replay to confirm what broke before you tune anything else.`,
+          primaryLabel: 'Open Replay',
+          onPrimary: () => setSelectedRoom('replay'),
+          secondaryLabel: failedReplayStep?.title ? `Focus ${failedReplayStep.title}` : undefined,
+          onSecondary: failedReplayStep?.title ? () => setSelectedRoom('replay') : undefined,
+        }
+      : selectedRoom === 'replay'
+        ? {
+            eyebrow: 'Control loop',
+            title: 'Next: test the fix in Optimize',
+            body: `Replay already identified the break. Move into Optimize and pressure-test ${candidateRun.experimentLabel} against the healthy control.`,
+            primaryLabel: 'Open Optimize',
+            onPrimary: () => setSelectedRoom('optimize'),
+            secondaryLabel: 'Back to Live',
+            onSecondary: () => setSelectedRoom('live'),
+          }
+        : {
+            eyebrow: 'Control loop',
+            title: 'Next: validate the promoted system in Live',
+            body: `${candidateRun.experimentLabel} looks strong enough to ship. Move back to Live and confirm the loop still feels healthy after the release call.`,
+            primaryLabel: 'Open Live',
+            onPrimary: () => setSelectedRoom('live'),
+            secondaryLabel: 'Re-open Replay',
+            onSecondary: () => setSelectedRoom('replay'),
+          };
 
   function dismissOnboarding() {
     setShowOnboarding(false);
@@ -409,6 +450,24 @@ export function App() {
                 <small>{ROOM_LABELS[room].summary}</small>
               </button>
             ))}
+          </div>
+        </section>
+
+        <section className="control-strip surface">
+          <div className="control-strip__copy">
+            <p className="eyebrow">{controlLoopCue.eyebrow}</p>
+            <h2>{controlLoopCue.title}</h2>
+            <p className="muted">{controlLoopCue.body}</p>
+          </div>
+          <div className="control-strip__actions">
+            <button type="button" className="control-strip__primary" onClick={controlLoopCue.onPrimary}>
+              {controlLoopCue.primaryLabel}
+            </button>
+            {controlLoopCue.secondaryLabel && controlLoopCue.onSecondary ? (
+              <button type="button" className="ghost-button" onClick={controlLoopCue.onSecondary}>
+                {controlLoopCue.secondaryLabel}
+              </button>
+            ) : null}
           </div>
         </section>
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -15,6 +15,7 @@ import { ReplayAdvancedPanel } from '../features/replay/ReplayAdvancedPanel';
 import { ReplayPanel } from '../features/replay/ReplayPanel';
 import { SystemOverviewRoute } from '../features/system/SystemOverviewRoute';
 import {
+  buildSystemWorkflowState,
   getAgentLabel,
   getWorkflowIdForSystem,
   sortSystemsByActivity,
@@ -248,8 +249,9 @@ export function App() {
     null;
   const selectedSystemWorkflowId = getWorkflowIdForSystem(selectedSystemState);
   const defaultWorkflowState = demoState ? demoState.workflowStates[demoState.defaultWorkflowId] ?? null : null;
-  const selectedWorkflowState =
+  const seededWorkflowState =
     demoState && selectedSystemWorkflowId ? demoState.workflowStates[selectedSystemWorkflowId] ?? null : selectedSystemState ? null : defaultWorkflowState;
+  const selectedWorkflowState = seededWorkflowState ?? buildSystemWorkflowState(selectedSystemState);
   const hasRoomProjection = Boolean(selectedWorkflowState);
   const workflow = selectedWorkflowState?.workflow ?? null;
   const liveRun = selectedWorkflowState?.live.run ?? null;
@@ -331,6 +333,19 @@ export function App() {
 
     setSelectedAgentId(selectedSystemSummary?.pressureAgentId ?? selectedControlPlaneSystem.agents[0]?.agentId ?? '');
   }, [selectedAgentId, selectedControlPlaneSystem, selectedSystemSummary?.pressureAgentId]);
+
+  useEffect(() => {
+    if (!selectedControlPlaneSystem) {
+      return;
+    }
+
+    const preferredRuntimeId = selectedControlPlaneSystem.system.primaryRuntimeId ?? selectedControlPlaneSystem.system.runtimeIds[0];
+    if (!preferredRuntimeId || preferredRuntimeId === runtimeId) {
+      return;
+    }
+
+    setRuntimeId(preferredRuntimeId);
+  }, [runtimeId, selectedControlPlaneSystem]);
 
   useEffect(() => {
     if (!selectedControlPlaneSystem || selectedView === 'connect') {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { startTransition, useEffect, useState } from 'react';
 
+import { loadControlPlaneState, type ControlPlaneState } from './control-plane';
 import { loadDemoState, type DemoState } from './demo';
 import { formatCredits, formatDuration, titleCaseStatus } from './format';
 import { RoomShell } from './RoomShell';
@@ -125,6 +126,7 @@ const ROOM_COPY: Record<
 
 export function App() {
   const [demoState, setDemoState] = useState<DemoState | null>(null);
+  const [controlPlaneState, setControlPlaneState] = useState<ControlPlaneState | null>(null);
   const [runtimeId, setRuntimeId] = useState<string>('demo');
   const [workflowId, setWorkflowId] = useState<string>('');
   const [selectedRoom, setSelectedRoom] = useState<RoomId>('live');
@@ -139,25 +141,26 @@ export function App() {
   useEffect(() => {
     let cancelled = false;
 
-    loadDemoState()
-      .then((state) => {
+    Promise.allSettled([loadDemoState(), loadControlPlaneState()])
+      .then(([demoResult, controlPlaneResult]) => {
         if (cancelled) {
+          return;
+        }
+
+        if (demoResult.status === 'rejected') {
+          setLoadError(demoResult.reason instanceof Error ? demoResult.reason.message : 'Failed to load demo state.');
           return;
         }
 
         startTransition(() => {
-          setDemoState(state);
-          setRuntimeId(state.runtimeOptions[0]?.id ?? 'demo');
-          setWorkflowId((current) => (current && state.workflowStates[current] ? current : state.defaultWorkflowId));
+          setDemoState(demoResult.value);
+          setRuntimeId(demoResult.value.runtimeOptions[0]?.id ?? 'demo');
+          setWorkflowId((current) =>
+            current && demoResult.value.workflowStates[current] ? current : demoResult.value.defaultWorkflowId,
+          );
+          setControlPlaneState(controlPlaneResult.status === 'fulfilled' ? controlPlaneResult.value : null);
           setLoadError(null);
         });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) {
-          return;
-        }
-
-        setLoadError(error instanceof Error ? error.message : 'Failed to load demo state.');
       });
 
     return () => {
@@ -217,6 +220,7 @@ export function App() {
     ((candidateRun.durationMs ?? 0) - (selectedWorkflowState.optimize.baselineRun.durationMs ?? 0)) / 1000,
   );
   const selectedRuntime = demoState.runtimeOptions.find((option) => option.id === runtimeId);
+  const selectedControlPlaneSystem = controlPlaneState?.systemsByWorkflowId[workflow.workflowId] ?? null;
 
   const controlLoopCue: ControlLoopCue =
     selectedRoom === 'live'
@@ -487,7 +491,12 @@ export function App() {
             openLabel={ROOM_COPY.live.openLabel}
             closeLabel={ROOM_COPY.live.closeLabel}
           >
-            <LivePanel workflow={workflow} run={selectedWorkflowState.live.run} replay={selectedWorkflowState.live.replay} />
+            <LivePanel
+              workflow={workflow}
+              run={selectedWorkflowState.live.run}
+              replay={selectedWorkflowState.live.replay}
+              controlPlane={selectedControlPlaneSystem}
+            />
           </RoomShell>
         ) : null}
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -4,6 +4,8 @@ import { loadControlPlaneState, type ControlPlaneState } from './control-plane';
 import { loadDemoState, type DemoState } from './demo';
 import { formatCredits, formatDuration, titleCaseStatus } from './format';
 import { RoomShell } from './RoomShell';
+import { buildAppRoute, parseAppRoute, type AppRouteState, type ViewId } from './routes';
+import { ConnectPanel } from '../features/connect/ConnectPanel';
 import { LiveAdvancedPanel } from '../features/live/LiveAdvancedPanel';
 import { LivePanel } from '../features/live/LivePanel';
 import { OnboardingPanel } from '../features/onboarding/OnboardingPanel';
@@ -11,10 +13,7 @@ import { OptimizeAdvancedPanel } from '../features/optimize/OptimizeAdvancedPane
 import { OptimizePanel } from '../features/optimize/OptimizePanel';
 import { ReplayAdvancedPanel } from '../features/replay/ReplayAdvancedPanel';
 import { ReplayPanel } from '../features/replay/ReplayPanel';
-import { AgentDetailPanel } from '../features/system/AgentDetailPanel';
-import { AgentFleetPanel } from '../features/system/AgentFleetPanel';
-import { SystemCatalogPanel } from '../features/system/SystemCatalogPanel';
-import { SystemPerformancePanel } from '../features/system/SystemPerformancePanel';
+import { SystemOverviewRoute } from '../features/system/SystemOverviewRoute';
 import {
   getAgentLabel,
   getWorkflowIdForSystem,
@@ -34,14 +33,52 @@ type ControlLoopCue = {
   onSecondary?: () => void;
 };
 
-const ROOM_LABELS: Record<
-  RoomId,
+const ONBOARDING_STORAGE_KEY = 'agent-studio-demo-onboarding-dismissed';
+
+function getInitialRouteState(): AppRouteState {
+  if (typeof window === 'undefined') {
+    return {
+      view: 'overview',
+      systemId: null,
+    };
+  }
+
+  return parseAppRoute(window.location.pathname);
+}
+
+function getInitialOnboardingState() {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  try {
+    return window.localStorage.getItem(ONBOARDING_STORAGE_KEY) !== 'true';
+  } catch {
+    return true;
+  }
+}
+
+function formatTokenLabel(value: string) {
+  return value
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+const VIEW_LABELS: Record<
+  ViewId,
   {
     title: string;
     summary: string;
     path: string;
   }
 > = {
+  overview: {
+    title: 'Overview',
+    summary: 'Operate the full system',
+    path: 'System',
+  },
   live: {
     title: 'Live',
     summary: 'Operate the current system',
@@ -57,24 +94,15 @@ const ROOM_LABELS: Record<
     summary: 'Test and release changes',
     path: 'Release',
   },
+  connect: {
+    title: 'Connect',
+    summary: 'Register and import systems',
+    path: 'Import',
+  },
 };
 
-const ONBOARDING_STORAGE_KEY = 'agent-studio-demo-onboarding-dismissed';
-
-function getInitialOnboardingState() {
-  if (typeof window === 'undefined') {
-    return true;
-  }
-
-  try {
-    return window.localStorage.getItem(ONBOARDING_STORAGE_KEY) !== 'true';
-  } catch {
-    return true;
-  }
-}
-
 const ROOM_COPY: Record<
-  RoomId,
+  Exclude<ViewId, 'overview' | 'connect'>,
   {
     eyebrow: string;
     title: string;
@@ -135,13 +163,14 @@ const ROOM_COPY: Record<
 };
 
 export function App() {
+  const initialRoute = getInitialRouteState();
   const [demoState, setDemoState] = useState<DemoState | null>(null);
   const [controlPlaneState, setControlPlaneState] = useState<ControlPlaneState | null>(null);
+  const [selectedView, setSelectedView] = useState<ViewId>(initialRoute.view);
   const [runtimeId, setRuntimeId] = useState<string>('demo');
-  const [systemId, setSystemId] = useState<string>('');
+  const [systemId, setSystemId] = useState<string>(initialRoute.systemId ?? '');
   const [selectedAgentId, setSelectedAgentId] = useState<string>('');
   const [workflowId, setWorkflowId] = useState<string>('');
-  const [selectedRoom, setSelectedRoom] = useState<RoomId>('live');
   const [showOnboarding, setShowOnboarding] = useState(getInitialOnboardingState);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState<Record<RoomId, boolean>>({
@@ -167,13 +196,17 @@ export function App() {
         startTransition(() => {
           const initialSystem =
             controlPlaneResult.status === 'fulfilled'
-              ? controlPlaneResult.value.systemsByWorkflowId[demoResult.value.defaultWorkflowId] ??
+              ? controlPlaneResult.value.systems.find((systemState) => systemState.system.systemId === initialRoute.systemId) ??
+                controlPlaneResult.value.systemsByWorkflowId[demoResult.value.defaultWorkflowId] ??
                 sortSystemsByActivity(controlPlaneResult.value.systems)[0] ??
                 null
               : null;
+          const initialRuntimeId =
+            initialSystem?.system.primaryRuntimeId ?? initialSystem?.system.runtimeIds[0] ?? demoResult.value.runtimeOptions[0]?.id ?? 'demo';
+
           setDemoState(demoResult.value);
-          setRuntimeId(demoResult.value.runtimeOptions[0]?.id ?? 'demo');
-          setSystemId(initialSystem?.system.systemId ?? '');
+          setRuntimeId(initialRuntimeId);
+          setSystemId(initialRoute.view === 'connect' ? '' : initialSystem?.system.systemId ?? initialRoute.systemId ?? '');
           setSelectedAgentId(initialSystem?.agents[0]?.agentId ?? '');
           setWorkflowId(
             getWorkflowIdForSystem(initialSystem) ??
@@ -189,17 +222,35 @@ export function App() {
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    function syncRouteFromLocation() {
+      const route = parseAppRoute(window.location.pathname);
+      setSelectedView(route.view);
+      setSystemId(route.systemId ?? '');
+    }
+
+    window.addEventListener('popstate', syncRouteFromLocation);
+
+    return () => {
+      window.removeEventListener('popstate', syncRouteFromLocation);
+    };
+  }, []);
+
   const sortedSystems = controlPlaneState ? sortSystemsByActivity(controlPlaneState.systems) : [];
   const selectedSystemState =
     sortedSystems.find((systemState) => systemState.system.systemId === systemId) ??
     controlPlaneState?.systemsByWorkflowId[workflowId] ??
     sortedSystems[0] ??
     null;
-  const effectiveWorkflowId = getWorkflowIdForSystem(selectedSystemState) ?? workflowId;
+  const selectedSystemWorkflowId = getWorkflowIdForSystem(selectedSystemState);
+  const defaultWorkflowState = demoState ? demoState.workflowStates[demoState.defaultWorkflowId] ?? null : null;
   const selectedWorkflowState =
-    demoState && effectiveWorkflowId
-      ? demoState.workflowStates[effectiveWorkflowId] ?? demoState.workflowStates[demoState.defaultWorkflowId]
-      : null;
+    demoState && selectedSystemWorkflowId ? demoState.workflowStates[selectedSystemWorkflowId] ?? null : selectedSystemState ? null : defaultWorkflowState;
+  const hasRoomProjection = Boolean(selectedWorkflowState);
   const workflow = selectedWorkflowState?.workflow ?? null;
   const liveRun = selectedWorkflowState?.live.run ?? null;
   const replayRun = selectedWorkflowState?.replay.run ?? null;
@@ -216,10 +267,57 @@ export function App() {
     candidateRun != null
       ? Math.round(((candidateRun.durationMs ?? 0) - (selectedWorkflowState?.optimize.baselineRun.durationMs ?? 0)) / 1000)
       : 0;
-  const selectedRuntime = demoState?.runtimeOptions.find((option) => option.id === runtimeId) ?? null;
+  const runtimeOptions =
+    controlPlaneState?.runtimes.length
+      ? controlPlaneState.runtimes.map((runtime) => ({
+          id: runtime.runtimeId,
+          label: runtime.label,
+          detail: `${formatTokenLabel(runtime.kind)} runtime · ${runtime.adapterId}`,
+        }))
+      : demoState?.runtimeOptions ?? [];
+  const selectedRuntime = runtimeOptions.find((option) => option.id === runtimeId) ?? null;
   const selectedControlPlaneSystem = selectedSystemState ?? (workflow ? controlPlaneState?.systemsByWorkflowId[workflow.workflowId] ?? null : null);
   const selectedSystemSummary = summarizeSystem(selectedControlPlaneSystem);
   const pressureAgentLabel = getAgentLabel(selectedControlPlaneSystem, selectedSystemSummary?.pressureAgentId ?? undefined);
+  const currentStateStatus = selectedSystemSummary?.latestExecution?.status ?? liveRun?.status ?? 'active';
+  const currentStateName = selectedControlPlaneSystem?.system.name ?? workflow?.name ?? 'Seeded demo system';
+  const currentStateDescription =
+    selectedControlPlaneSystem?.system.description ?? workflow?.description ?? 'A seeded control-room demo with runtime-aware routes.';
+  const replayPressureSummary = hasRoomProjection
+    ? failedReplayStep?.error ?? failedReplayStep?.summary ?? 'No active pressure point is recorded in the current system.'
+    : selectedSystemSummary?.pressureAgentId
+      ? 'This system has a hot agent in the registry, but it does not yet map to a seeded replay walkthrough.'
+      : 'Import executions and spans to light up Replay for this system.';
+  const releaseHeadline = hasRoomProjection
+    ? candidateCreditsDelta < 0
+      ? `${Math.abs(candidateCreditsDelta)} credits leaner`
+      : 'Guardrails preserved'
+    : selectedSystemSummary?.latestRelease
+      ? formatTokenLabel(selectedSystemSummary.latestRelease.decision)
+      : selectedSystemSummary?.latestEvaluation
+        ? titleCaseStatus(selectedSystemSummary.latestEvaluation.verdict)
+        : 'No release evidence yet';
+  const releaseSummary = hasRoomProjection
+    ? selectedWorkflowState?.optimize.promotionSummary ?? 'No promotion story recorded.'
+    : selectedSystemSummary?.latestRelease?.summary ??
+      selectedSystemSummary?.latestEvaluation?.summary ??
+      'Import evaluations and release decisions to turn Optimize into a real release workbench.';
+
+  function navigateTo(view: ViewId, nextSystemId = systemId || selectedControlPlaneSystem?.system.systemId || null, replace = false) {
+    const targetPath = buildAppRoute({
+      view,
+      systemId: view === 'connect' ? null : nextSystemId,
+    });
+
+    setSelectedView(view);
+    if (view !== 'connect') {
+      setSystemId(nextSystemId ?? '');
+    }
+
+    if (typeof window !== 'undefined') {
+      window.history[replace ? 'replaceState' : 'pushState']({}, '', targetPath);
+    }
+  }
 
   useEffect(() => {
     if (!selectedControlPlaneSystem?.agents.length) {
@@ -233,6 +331,19 @@ export function App() {
 
     setSelectedAgentId(selectedSystemSummary?.pressureAgentId ?? selectedControlPlaneSystem.agents[0]?.agentId ?? '');
   }, [selectedAgentId, selectedControlPlaneSystem, selectedSystemSummary?.pressureAgentId]);
+
+  useEffect(() => {
+    if (!selectedControlPlaneSystem || selectedView === 'connect') {
+      return;
+    }
+
+    const route = parseAppRoute(typeof window !== 'undefined' ? window.location.pathname : '/');
+    if (route.systemId === selectedControlPlaneSystem.system.systemId && route.view === selectedView) {
+      return;
+    }
+
+    navigateTo(selectedView, selectedControlPlaneSystem.system.systemId, true);
+  }, [selectedControlPlaneSystem, selectedView]);
 
   if (loadError) {
     return (
@@ -253,7 +364,7 @@ export function App() {
     );
   }
 
-  if (!demoState || !selectedWorkflowState || !workflow || !liveRun || !replayRun || !candidateRun) {
+  if (!demoState) {
     return (
       <main className="app-shell">
         <div className="app-shell__backdrop" />
@@ -275,42 +386,94 @@ export function App() {
   function handleSystemChange(nextSystemId: string) {
     setSystemId(nextSystemId);
     const nextSystem = sortedSystems.find((systemState) => systemState.system.systemId === nextSystemId) ?? null;
+    setRuntimeId(nextSystem?.system.primaryRuntimeId ?? nextSystem?.system.runtimeIds[0] ?? runtimeId);
     setSelectedAgentId(nextSystem?.agents[0]?.agentId ?? '');
     const nextWorkflowId = getWorkflowIdForSystem(nextSystem);
     if (nextWorkflowId) {
       setWorkflowId(nextWorkflowId);
     }
+    navigateTo(selectedView === 'connect' ? 'overview' : selectedView, nextSystemId);
+  }
+
+  async function handleRefreshControlPlane(nextSystemId?: string) {
+    const nextState = await loadControlPlaneState();
+    setControlPlaneState(nextState);
+
+    if (nextSystemId) {
+      navigateTo(selectedView === 'connect' ? 'overview' : selectedView, nextSystemId, true);
+      return;
+    }
+
+    if (!nextState.systems.length) {
+      return;
+    }
+
+    const refreshedSystem =
+      nextState.systems.find((systemState) => systemState.system.systemId === (selectedControlPlaneSystem?.system.systemId ?? systemId)) ??
+      sortSystemsByActivity(nextState.systems)[0];
+
+    if (refreshedSystem) {
+      navigateTo(selectedView === 'connect' ? 'overview' : selectedView, refreshedSystem.system.systemId, true);
+    }
   }
 
   const controlLoopCue: ControlLoopCue =
-    selectedRoom === 'live'
+    selectedView === 'overview'
       ? {
           eyebrow: 'Control loop',
-          title: 'Next: open Replay',
-          body: `${replayRun.experimentLabel} is the clearest weak run in the loop. Use Replay to confirm what broke before you tune anything else.`,
-          primaryLabel: 'Open Replay',
-          onPrimary: () => setSelectedRoom('replay'),
-          secondaryLabel: failedReplayStep?.title ? `Focus ${failedReplayStep.title}` : undefined,
-          onSecondary: failedReplayStep?.title ? () => setSelectedRoom('replay') : undefined,
+          title: 'Start from the live system',
+          body: 'Use the overview to find the right system and hot agents, then move into Live when you want to operate the active execution path.',
+          primaryLabel: 'Open Live',
+          onPrimary: () => navigateTo('live'),
+          secondaryLabel: 'Open Connect',
+          onSecondary: () => navigateTo('connect', null),
         }
-      : selectedRoom === 'replay'
+      : selectedView === 'connect'
+        ? {
+            eyebrow: 'Control loop',
+            title: 'Next: return to the system overview',
+            body: 'After you register or import a system, come back to Overview to inspect fleet health and decide where to drill in.',
+            primaryLabel: 'Open Overview',
+            onPrimary: () => navigateTo('overview'),
+          }
+      : !hasRoomProjection
+        ? {
+            eyebrow: 'Control loop',
+            title: 'This room needs trace-backed system history',
+            body: 'The system is registered, but there is no seeded room projection for it yet. Import executions, spans, evaluations, and releases, or attach a workflowId if you want to reuse the seeded walkthrough.',
+            primaryLabel: 'Open Connect',
+            onPrimary: () => navigateTo('connect', null),
+            secondaryLabel: 'Open Overview',
+            onSecondary: () => navigateTo('overview'),
+          }
+      : selectedView === 'live'
+        ? {
+            eyebrow: 'Control loop',
+            title: 'Next: open Replay',
+            body: `${replayRun?.experimentLabel ?? 'The selected replay'} is the clearest weak run in the loop. Use Replay to confirm what broke before you tune anything else.`,
+            primaryLabel: 'Open Replay',
+            onPrimary: () => navigateTo('replay'),
+            secondaryLabel: failedReplayStep?.title ? `Focus ${failedReplayStep.title}` : undefined,
+            onSecondary: failedReplayStep?.title ? () => navigateTo('replay') : undefined,
+          }
+        : selectedView === 'replay'
         ? {
             eyebrow: 'Control loop',
             title: 'Next: test the fix in Optimize',
-            body: `Replay already identified the break. Move into Optimize and pressure-test ${candidateRun.experimentLabel} against the healthy control.`,
+            body: `Replay already identified the break. Move into Optimize and pressure-test ${candidateRun?.experimentLabel ?? 'the current candidate'} against the healthy control.`,
             primaryLabel: 'Open Optimize',
-            onPrimary: () => setSelectedRoom('optimize'),
+            onPrimary: () => navigateTo('optimize'),
             secondaryLabel: 'Back to Live',
-            onSecondary: () => setSelectedRoom('live'),
+            onSecondary: () => navigateTo('live'),
           }
         : {
             eyebrow: 'Control loop',
             title: 'Next: validate the promoted system in Live',
-            body: `${candidateRun.experimentLabel} looks strong enough to ship. Move back to Live and confirm the loop still feels healthy after the release call.`,
+            body: `${candidateRun?.experimentLabel ?? 'The current candidate'} looks strong enough to ship. Move back to Live and confirm the loop still feels healthy after the release call.`,
             primaryLabel: 'Open Live',
-            onPrimary: () => setSelectedRoom('live'),
+            onPrimary: () => navigateTo('live'),
             secondaryLabel: 'Re-open Replay',
-            onSecondary: () => setSelectedRoom('replay'),
+            onSecondary: () => navigateTo('replay'),
           };
 
   function dismissOnboarding() {
@@ -330,6 +493,42 @@ export function App() {
     }));
   }
 
+  function renderProjectionUnavailableRoom(room: RoomId) {
+    return (
+      <section className="surface overview-panel">
+        <div className="section-header">
+          <div>
+            <p className="eyebrow">{VIEW_LABELS[room].title}</p>
+            <h2>No seeded room projection for this system</h2>
+            <p className="muted overview-panel__body">
+              This system is visible in the control plane, but this room still depends on trace-backed walkthrough data.
+              Import executions, spans, evaluations, and releases, or attach `metadata.workflowId` if you want to reuse
+              the seeded workflow projection.
+            </p>
+          </div>
+          <span className="meta-chip">{selectedControlPlaneSystem?.system.name ?? 'No system selected'}</span>
+        </div>
+        <div className="signal-band">
+          <article className="signal-band__card">
+            <span className="eyebrow">Tracked agents</span>
+            <strong>{selectedSystemSummary?.agentCount ?? 0}</strong>
+            <p>{selectedSystemSummary?.executionCount ?? 0} executions currently registered for this system.</p>
+          </article>
+          <article className="signal-band__card signal-band__card--directive">
+            <span className="eyebrow">Pressure point</span>
+            <strong>{pressureAgentLabel ?? 'No hot agent yet'}</strong>
+            <p>{replayPressureSummary}</p>
+          </article>
+          <article className="signal-band__card signal-band__card--accent">
+            <span className="eyebrow">Next move</span>
+            <strong>Open Connect</strong>
+            <p>Bring in trace, evaluation, and release evidence so this room can switch from placeholder to real control-plane mode.</p>
+          </article>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <main className="app-shell">
       <div className="app-shell__backdrop" />
@@ -345,12 +544,12 @@ export function App() {
             <div className="hero__current-state">
               <div className="hero__state-copy">
                 <span className="hero__state-label">Current state</span>
-                <strong>{selectedControlPlaneSystem?.system.name ?? workflow.name}</strong>
-                <p>{selectedControlPlaneSystem?.system.description ?? workflow.description}</p>
+                <strong>{currentStateName}</strong>
+                <p>{currentStateDescription}</p>
               </div>
               <div className="hero__state-line">
-                <span className={`status-pill status-pill--${selectedSystemSummary?.latestExecution?.status ?? liveRun.status}`}>
-                  {titleCaseStatus(selectedSystemSummary?.latestExecution?.status ?? liveRun.status)}
+                <span className={`status-pill status-pill--${currentStateStatus}`}>
+                  {titleCaseStatus(currentStateStatus)}
                 </span>
                 <span className="meta-chip">{selectedSystemSummary?.agentCount ?? 0} agents</span>
                 <span className="meta-chip">{selectedSystemSummary?.executionCount ?? 0} executions</span>
@@ -370,7 +569,7 @@ export function App() {
               <label className="select-field">
                 <span>Runtime</span>
                 <select aria-label="Runtime" value={runtimeId} onChange={(event) => setRuntimeId(event.target.value)}>
-                  {demoState.runtimeOptions.map((option) => (
+                  {runtimeOptions.map((option) => (
                     <option key={option.id} value={option.id}>
                       {option.label}
                     </option>
@@ -392,7 +591,7 @@ export function App() {
                       </option>
                     ))}
                   </select>
-                  <small>{selectedControlPlaneSystem?.system.description ?? workflow.description}</small>
+                  <small>{selectedControlPlaneSystem?.system.description ?? currentStateDescription}</small>
                 </label>
               ) : (
                 <label className="select-field">
@@ -404,36 +603,36 @@ export function App() {
                       </option>
                     ))}
                   </select>
-                  <small>{workflow.description}</small>
+                  <small>{workflow?.description ?? currentStateDescription}</small>
                 </label>
               )}
             </div>
             <div className="hero__status-grid">
               <article className="hero-signal hero-signal--live">
                 <span className="hero-signal__label">Live posture</span>
-                <strong>{titleCaseStatus(selectedSystemSummary?.latestExecution?.status ?? liveRun.status)}</strong>
-                <p>{selectedControlPlaneSystem?.system.name ?? liveRun.experimentLabel}</p>
+                <strong>{titleCaseStatus(currentStateStatus)}</strong>
+                <p>{currentStateName}</p>
                 <div className="hero-signal__meta">
-                  <span>{formatCredits(selectedSystemSummary?.avgCredits ?? liveRun.actualCredits)}</span>
-                  <span>{formatDuration(selectedSystemSummary?.avgDurationMs ?? liveRun.durationMs)}</span>
+                  <span>{formatCredits(selectedSystemSummary?.avgCredits ?? liveRun?.actualCredits)}</span>
+                  <span>{formatDuration(selectedSystemSummary?.avgDurationMs ?? liveRun?.durationMs)}</span>
                 </div>
               </article>
               <article className="hero-signal hero-signal--replay">
                 <span className="hero-signal__label">Replay pressure</span>
                 <strong>{pressureAgentLabel ?? failedReplayStep?.title ?? 'No failing step'}</strong>
-                <p>{failedReplayStep?.error ?? failedReplayStep?.summary ?? 'No active pressure point is recorded in the current system.'}</p>
+                <p>{replayPressureSummary}</p>
                 <div className="hero-signal__meta">
-                  <span>{titleCaseStatus(replayRun.status)}</span>
-                  <span>{formatCredits(replayRun.actualCredits)}</span>
+                  <span>{replayRun ? titleCaseStatus(replayRun.status) : `${selectedSystemSummary?.executionCount ?? 0} executions`}</span>
+                  <span>{formatCredits(replayRun?.actualCredits ?? selectedSystemSummary?.avgCredits)}</span>
                 </div>
               </article>
               <article className="hero-signal hero-signal--optimize">
                 <span className="hero-signal__label">Release call</span>
-                <strong>{candidateCreditsDelta < 0 ? `${Math.abs(candidateCreditsDelta)} credits leaner` : 'Guardrails preserved'}</strong>
-                <p>{selectedWorkflowState.optimize.promotionSummary}</p>
+                <strong>{releaseHeadline}</strong>
+                <p>{releaseSummary}</p>
                 <div className="hero-signal__meta">
-                  <span>{candidateDurationDeltaSeconds < 0 ? `${Math.abs(candidateDurationDeltaSeconds)}s faster` : 'No speed gain'}</span>
-                  <span>{selectedWorkflowState.optimize.candidatePlan?.name ?? 'Saved plan'}</span>
+                  <span>{hasRoomProjection ? (candidateDurationDeltaSeconds < 0 ? `${Math.abs(candidateDurationDeltaSeconds)}s faster` : 'No speed gain') : 'Control-plane evidence'}</span>
+                  <span>{selectedWorkflowState?.optimize.candidatePlan?.name ?? selectedSystemSummary?.latestRelease?.releaseId ?? 'Release audit'}</span>
                 </div>
               </article>
             </div>
@@ -449,118 +648,26 @@ export function App() {
           />
         ) : null}
 
-        {sortedSystems.length ? (
-          <SystemCatalogPanel
-            systems={sortedSystems}
-            selectedSystemId={selectedControlPlaneSystem?.system.systemId ?? null}
-            onSelectSystem={handleSystemChange}
-          />
-        ) : null}
-
-        {selectedControlPlaneSystem ? (
-          <section className="system-layout">
-            <AgentFleetPanel
-              systemState={selectedControlPlaneSystem}
-              selectedAgentId={selectedAgentId || null}
-              onSelectAgent={setSelectedAgentId}
-            />
-            <AgentDetailPanel systemState={selectedControlPlaneSystem} agentId={selectedAgentId || null} />
-          </section>
-        ) : null}
-
-        {selectedControlPlaneSystem ? <SystemPerformancePanel systemState={selectedControlPlaneSystem} /> : null}
-
-        <section className="surface overview-panel">
-          <div className="section-header">
-            <div>
-              <p className="eyebrow">Control loop</p>
-              <h2>Live, Replay, Optimize</h2>
-              <p className="muted overview-panel__body">One operating loop: inspect the live system, explain the weak run, then ship a safer candidate.</p>
-            </div>
-            <span className="meta-chip">Demo mode only</span>
-          </div>
-          <div className="overview-grid">
-            <article className="overview-card overview-card--live">
-              <div className="overview-card__header">
-                <div>
-                  <p className="eyebrow">01 · Live</p>
-                  <h3>{selectedWorkflowState.live.run.experimentLabel}</h3>
-                </div>
-                <span className={`status-pill status-pill--${selectedWorkflowState.live.run.status}`}>
-                  {titleCaseStatus(selectedWorkflowState.live.run.status)}
-                </span>
-              </div>
-              <p className="overview-card__summary">Operate the current system before you touch history or overrides.</p>
-              <div className="overview-card__metric">
-                <span>Current workflow</span>
-                <strong>{workflow.name}</strong>
-              </div>
-              <div className="overview-card__path">
-                <span>{formatCredits(selectedWorkflowState.live.run.actualCredits)}</span>
-                <span>{formatDuration(selectedWorkflowState.live.run.durationMs)}</span>
-              </div>
-            </article>
-            <article className="overview-card overview-card--replay">
-              <div className="overview-card__header">
-                <div>
-                  <p className="eyebrow">02 · Replay</p>
-                  <h3>{selectedWorkflowState.replay.run.experimentLabel}</h3>
-                </div>
-                <span className={`status-pill status-pill--${selectedWorkflowState.replay.run.status}`}>
-                  {titleCaseStatus(selectedWorkflowState.replay.run.status)}
-                </span>
-              </div>
-              <p className="overview-card__summary">Find the exact break and turn it into the next fix, not another theory.</p>
-              <div className="overview-card__metric overview-card__metric--warning">
-                <span>Pressure point</span>
-                <strong>{failedReplayStep?.title ?? 'No failed step recorded'}</strong>
-              </div>
-              <div className="overview-card__path">
-                <span>{failedReplayStep?.assignedRole ?? 'reviewer'}</span>
-                <span>{formatCredits(selectedWorkflowState.replay.run.actualCredits)}</span>
-              </div>
-            </article>
-            <article className="overview-card overview-card--optimize">
-              <div className="overview-card__header">
-                <div>
-                  <p className="eyebrow">03 · Optimize</p>
-                  <h3>{selectedWorkflowState.optimize.candidateRun.experimentLabel}</h3>
-                </div>
-                <span className="status-pill status-pill--succeeded">Promotion-ready</span>
-              </div>
-              <p className="overview-card__summary">Compare the candidate against the healthy control and only ship what clearly improves the loop.</p>
-              <div className="overview-card__metric overview-card__metric--success">
-                <span>Release delta</span>
-                <strong>{candidateCreditsDelta < 0 ? `${Math.abs(candidateCreditsDelta)} credits saved` : 'Stable quality retained'}</strong>
-              </div>
-              <div className="overview-card__path">
-                <span>{selectedWorkflowState.optimize.candidatePlan?.name ?? 'Saved plan'}</span>
-                <span>{candidateDurationDeltaSeconds < 0 ? `${Math.abs(candidateDurationDeltaSeconds)}s faster` : 'No speed gain'}</span>
-              </div>
-            </article>
-          </div>
-        </section>
-
         <section className="room-nav surface">
           <div className="room-nav__intro">
-            <p className="eyebrow">Room switcher</p>
-            <h2>Move through one mode at a time</h2>
-            <p className="muted">The mode switcher is the operating rhythm: observe, explain, release.</p>
+            <p className="eyebrow">System routes</p>
+            <h2>Move through the operating surface</h2>
+            <p className="muted">The URL now tracks where you are: overview, live, replay, optimize, or connect.</p>
           </div>
           <div className="room-nav__buttons" role="tablist" aria-label="Room switcher">
-            {(['live', 'replay', 'optimize'] as RoomId[]).map((room) => (
+            {(['overview', 'live', 'replay', 'optimize', 'connect'] as ViewId[]).map((view) => (
               <button
-                key={room}
+                key={view}
                 type="button"
                 role="tab"
-                aria-label={ROOM_LABELS[room].title}
-                aria-selected={selectedRoom === room}
-                className={`room-tab ${selectedRoom === room ? 'room-tab--active' : ''}`}
-                onClick={() => setSelectedRoom(room)}
+                aria-label={VIEW_LABELS[view].title}
+                aria-selected={selectedView === view}
+                className={`room-tab ${selectedView === view ? 'room-tab--active' : ''}`}
+                onClick={() => navigateTo(view)}
               >
-                <span className="room-tab__path">{ROOM_LABELS[room].path}</span>
-                <strong>{ROOM_LABELS[room].title}</strong>
-                <small>{ROOM_LABELS[room].summary}</small>
+                <span className="room-tab__path">{VIEW_LABELS[view].path}</span>
+                <strong>{VIEW_LABELS[view].title}</strong>
+                <small>{VIEW_LABELS[view].summary}</small>
               </button>
             ))}
           </div>
@@ -584,7 +691,23 @@ export function App() {
           </div>
         </section>
 
-        {selectedRoom === 'live' ? (
+        {selectedView === 'overview' ? (
+          <SystemOverviewRoute
+            demoState={demoState}
+            sortedSystems={sortedSystems}
+            selectedSystem={selectedControlPlaneSystem}
+            selectedWorkflowState={selectedWorkflowState}
+            selectedAgentId={selectedAgentId || null}
+            onSelectSystem={handleSystemChange}
+            onSelectAgent={setSelectedAgentId}
+          />
+        ) : null}
+
+        {selectedView === 'connect' ? (
+          <ConnectPanel selectedSystem={selectedControlPlaneSystem} onRefresh={handleRefreshControlPlane} />
+        ) : null}
+
+        {selectedView === 'live' && hasRoomProjection && selectedWorkflowState && workflow ? (
           <RoomShell
             roomId="live"
             eyebrow={ROOM_COPY.live.eyebrow}
@@ -609,7 +732,9 @@ export function App() {
           </RoomShell>
         ) : null}
 
-        {selectedRoom === 'replay' ? (
+        {selectedView === 'live' && !hasRoomProjection ? renderProjectionUnavailableRoom('live') : null}
+
+        {selectedView === 'replay' && hasRoomProjection && selectedWorkflowState ? (
           <RoomShell
             roomId="replay"
             eyebrow={ROOM_COPY.replay.eyebrow}
@@ -633,7 +758,9 @@ export function App() {
           </RoomShell>
         ) : null}
 
-        {selectedRoom === 'optimize' ? (
+        {selectedView === 'replay' && !hasRoomProjection ? renderProjectionUnavailableRoom('replay') : null}
+
+        {selectedView === 'optimize' && hasRoomProjection && selectedWorkflowState ? (
           <RoomShell
             roomId="optimize"
             eyebrow={ROOM_COPY.optimize.eyebrow}
@@ -665,6 +792,8 @@ export function App() {
             />
           </RoomShell>
         ) : null}
+
+        {selectedView === 'optimize' && !hasRoomProjection ? renderProjectionUnavailableRoom('optimize') : null}
       </div>
     </main>
   );

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -719,7 +719,11 @@ export function App() {
         ) : null}
 
         {selectedView === 'connect' ? (
-          <ConnectPanel selectedSystem={selectedControlPlaneSystem} onRefresh={handleRefreshControlPlane} />
+          <ConnectPanel
+            selectedSystem={selectedControlPlaneSystem}
+            storage={controlPlaneState?.storage ?? null}
+            onRefresh={handleRefreshControlPlane}
+          />
         ) : null}
 
         {selectedView === 'live' && hasRoomProjection && selectedWorkflowState && workflow ? (

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -535,6 +535,7 @@ export function App() {
               <OptimizeAdvancedPanel
                 savedPlans={selectedWorkflowState.optimize.candidateReplay.studioState?.savedPlans ?? []}
                 promotionHistory={selectedWorkflowState.optimize.promotionHistory}
+                controlPlane={selectedControlPlaneSystem}
               />
             }
             showAdvanced={advancedOpen.optimize}
@@ -551,6 +552,7 @@ export function App() {
               candidateReplay={selectedWorkflowState.optimize.candidateReplay}
               candidatePlan={selectedWorkflowState.optimize.candidatePlan}
               promotionSummary={selectedWorkflowState.optimize.promotionSummary}
+              controlPlane={selectedControlPlaneSystem}
             />
           </RoomShell>
         ) : null}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -11,6 +11,16 @@ import { OptimizeAdvancedPanel } from '../features/optimize/OptimizeAdvancedPane
 import { OptimizePanel } from '../features/optimize/OptimizePanel';
 import { ReplayAdvancedPanel } from '../features/replay/ReplayAdvancedPanel';
 import { ReplayPanel } from '../features/replay/ReplayPanel';
+import { AgentDetailPanel } from '../features/system/AgentDetailPanel';
+import { AgentFleetPanel } from '../features/system/AgentFleetPanel';
+import { SystemCatalogPanel } from '../features/system/SystemCatalogPanel';
+import { SystemPerformancePanel } from '../features/system/SystemPerformancePanel';
+import {
+  getAgentLabel,
+  getWorkflowIdForSystem,
+  sortSystemsByActivity,
+  summarizeSystem,
+} from './control-plane';
 
 type RoomId = 'live' | 'replay' | 'optimize';
 
@@ -128,6 +138,8 @@ export function App() {
   const [demoState, setDemoState] = useState<DemoState | null>(null);
   const [controlPlaneState, setControlPlaneState] = useState<ControlPlaneState | null>(null);
   const [runtimeId, setRuntimeId] = useState<string>('demo');
+  const [systemId, setSystemId] = useState<string>('');
+  const [selectedAgentId, setSelectedAgentId] = useState<string>('');
   const [workflowId, setWorkflowId] = useState<string>('');
   const [selectedRoom, setSelectedRoom] = useState<RoomId>('live');
   const [showOnboarding, setShowOnboarding] = useState(getInitialOnboardingState);
@@ -153,10 +165,19 @@ export function App() {
         }
 
         startTransition(() => {
+          const initialSystem =
+            controlPlaneResult.status === 'fulfilled'
+              ? controlPlaneResult.value.systemsByWorkflowId[demoResult.value.defaultWorkflowId] ??
+                sortSystemsByActivity(controlPlaneResult.value.systems)[0] ??
+                null
+              : null;
           setDemoState(demoResult.value);
           setRuntimeId(demoResult.value.runtimeOptions[0]?.id ?? 'demo');
-          setWorkflowId((current) =>
-            current && demoResult.value.workflowStates[current] ? current : demoResult.value.defaultWorkflowId,
+          setSystemId(initialSystem?.system.systemId ?? '');
+          setSelectedAgentId(initialSystem?.agents[0]?.agentId ?? '');
+          setWorkflowId(
+            getWorkflowIdForSystem(initialSystem) ??
+              demoResult.value.defaultWorkflowId,
           );
           setControlPlaneState(controlPlaneResult.status === 'fulfilled' ? controlPlaneResult.value : null);
           setLoadError(null);
@@ -167,6 +188,51 @@ export function App() {
       cancelled = true;
     };
   }, []);
+
+  const sortedSystems = controlPlaneState ? sortSystemsByActivity(controlPlaneState.systems) : [];
+  const selectedSystemState =
+    sortedSystems.find((systemState) => systemState.system.systemId === systemId) ??
+    controlPlaneState?.systemsByWorkflowId[workflowId] ??
+    sortedSystems[0] ??
+    null;
+  const effectiveWorkflowId = getWorkflowIdForSystem(selectedSystemState) ?? workflowId;
+  const selectedWorkflowState =
+    demoState && effectiveWorkflowId
+      ? demoState.workflowStates[effectiveWorkflowId] ?? demoState.workflowStates[demoState.defaultWorkflowId]
+      : null;
+  const workflow = selectedWorkflowState?.workflow ?? null;
+  const liveRun = selectedWorkflowState?.live.run ?? null;
+  const replayRun = selectedWorkflowState?.replay.run ?? null;
+  const failedReplayStep =
+    selectedWorkflowState?.replay.replay.stepExecutions.find((step) => step.status === 'failed') ??
+    selectedWorkflowState?.replay.replay.stepExecutions[0] ??
+    null;
+  const candidateRun = selectedWorkflowState?.optimize.candidateRun ?? null;
+  const candidateCreditsDelta =
+    candidateRun != null
+      ? (candidateRun.actualCredits ?? 0) - (selectedWorkflowState?.optimize.baselineRun.actualCredits ?? 0)
+      : 0;
+  const candidateDurationDeltaSeconds =
+    candidateRun != null
+      ? Math.round(((candidateRun.durationMs ?? 0) - (selectedWorkflowState?.optimize.baselineRun.durationMs ?? 0)) / 1000)
+      : 0;
+  const selectedRuntime = demoState?.runtimeOptions.find((option) => option.id === runtimeId) ?? null;
+  const selectedControlPlaneSystem = selectedSystemState ?? (workflow ? controlPlaneState?.systemsByWorkflowId[workflow.workflowId] ?? null : null);
+  const selectedSystemSummary = summarizeSystem(selectedControlPlaneSystem);
+  const pressureAgentLabel = getAgentLabel(selectedControlPlaneSystem, selectedSystemSummary?.pressureAgentId ?? undefined);
+
+  useEffect(() => {
+    if (!selectedControlPlaneSystem?.agents.length) {
+      return;
+    }
+
+    const hasSelectedAgent = selectedControlPlaneSystem.agents.some((agent) => agent.agentId === selectedAgentId);
+    if (hasSelectedAgent) {
+      return;
+    }
+
+    setSelectedAgentId(selectedSystemSummary?.pressureAgentId ?? selectedControlPlaneSystem.agents[0]?.agentId ?? '');
+  }, [selectedAgentId, selectedControlPlaneSystem, selectedSystemSummary?.pressureAgentId]);
 
   if (loadError) {
     return (
@@ -187,7 +253,7 @@ export function App() {
     );
   }
 
-  if (!demoState || !workflowId) {
+  if (!demoState || !selectedWorkflowState || !workflow || !liveRun || !replayRun || !candidateRun) {
     return (
       <main className="app-shell">
         <div className="app-shell__backdrop" />
@@ -206,21 +272,15 @@ export function App() {
     );
   }
 
-  const selectedWorkflowState =
-    demoState.workflowStates[workflowId] ?? demoState.workflowStates[demoState.defaultWorkflowId];
-  const workflow = selectedWorkflowState.workflow;
-  const liveRun = selectedWorkflowState.live.run;
-  const replayRun = selectedWorkflowState.replay.run;
-  const failedReplayStep =
-    selectedWorkflowState.replay.replay.stepExecutions.find((step) => step.status === 'failed') ??
-    selectedWorkflowState.replay.replay.stepExecutions[0];
-  const candidateRun = selectedWorkflowState.optimize.candidateRun;
-  const candidateCreditsDelta = (candidateRun.actualCredits ?? 0) - (selectedWorkflowState.optimize.baselineRun.actualCredits ?? 0);
-  const candidateDurationDeltaSeconds = Math.round(
-    ((candidateRun.durationMs ?? 0) - (selectedWorkflowState.optimize.baselineRun.durationMs ?? 0)) / 1000,
-  );
-  const selectedRuntime = demoState.runtimeOptions.find((option) => option.id === runtimeId);
-  const selectedControlPlaneSystem = controlPlaneState?.systemsByWorkflowId[workflow.workflowId] ?? null;
+  function handleSystemChange(nextSystemId: string) {
+    setSystemId(nextSystemId);
+    const nextSystem = sortedSystems.find((systemState) => systemState.system.systemId === nextSystemId) ?? null;
+    setSelectedAgentId(nextSystem?.agents[0]?.agentId ?? '');
+    const nextWorkflowId = getWorkflowIdForSystem(nextSystem);
+    if (nextWorkflowId) {
+      setWorkflowId(nextWorkflowId);
+    }
+  }
 
   const controlLoopCue: ControlLoopCue =
     selectedRoom === 'live'
@@ -279,19 +339,22 @@ export function App() {
             <p className="eyebrow">Public demo</p>
             <h1>Agent Studio</h1>
             <p className="hero__lede">
-              A seeded control room for agent workflows. The shell should tell you what state the system is in, what
-              changed, and whether the next candidate deserves to ship.
+              A seeded control room for bring-your-own multi-agent systems. The shell should start from the system,
+              expose agent pressure fast, and make the next intervention or release call obvious.
             </p>
             <div className="hero__current-state">
               <div className="hero__state-copy">
                 <span className="hero__state-label">Current state</span>
-                <strong>{workflow.name}</strong>
-                <p>{workflow.description}</p>
+                <strong>{selectedControlPlaneSystem?.system.name ?? workflow.name}</strong>
+                <p>{selectedControlPlaneSystem?.system.description ?? workflow.description}</p>
               </div>
               <div className="hero__state-line">
-                <span className={`status-pill status-pill--${liveRun.status}`}>{titleCaseStatus(liveRun.status)}</span>
-                <span className="meta-chip">Replay focus: {failedReplayStep?.title ?? 'Healthy control'}</span>
-                <span className="meta-chip">Candidate: {candidateRun.experimentLabel}</span>
+                <span className={`status-pill status-pill--${selectedSystemSummary?.latestExecution?.status ?? liveRun.status}`}>
+                  {titleCaseStatus(selectedSystemSummary?.latestExecution?.status ?? liveRun.status)}
+                </span>
+                <span className="meta-chip">{selectedSystemSummary?.agentCount ?? 0} agents</span>
+                <span className="meta-chip">{selectedSystemSummary?.executionCount ?? 0} executions</span>
+                <span className="meta-chip">Pressure: {pressureAgentLabel ?? failedReplayStep?.title ?? 'Healthy control'}</span>
               </div>
             </div>
           </div>
@@ -300,9 +363,9 @@ export function App() {
               <div className="hero__controls-header">
                 <div>
                   <p className="eyebrow">Command surface</p>
-                  <h2>Runtime and workflow</h2>
+                  <h2>Runtime and system</h2>
                 </div>
-                <span className="meta-chip">Demo operator view</span>
+                <span className="meta-chip">System-first operator view</span>
               </div>
               <label className="select-field">
                 <span>Runtime</span>
@@ -315,32 +378,50 @@ export function App() {
                 </select>
                 <small>{selectedRuntime?.detail}</small>
               </label>
-              <label className="select-field">
-                <span>Workflow</span>
-                <select aria-label="Workflow" value={workflowId} onChange={(event) => setWorkflowId(event.target.value)}>
-                  {demoState.workflows.map((option) => (
-                    <option key={option.workflowId} value={option.workflowId}>
-                      {option.name}
-                    </option>
-                  ))}
-                </select>
-                <small>{workflow.description}</small>
-              </label>
+              {sortedSystems.length ? (
+                <label className="select-field">
+                  <span>System</span>
+                  <select
+                    aria-label="System"
+                    value={selectedControlPlaneSystem?.system.systemId ?? ''}
+                    onChange={(event) => handleSystemChange(event.target.value)}
+                  >
+                    {sortedSystems.map((systemState) => (
+                      <option key={systemState.system.systemId} value={systemState.system.systemId}>
+                        {systemState.system.name}
+                      </option>
+                    ))}
+                  </select>
+                  <small>{selectedControlPlaneSystem?.system.description ?? workflow.description}</small>
+                </label>
+              ) : (
+                <label className="select-field">
+                  <span>Workflow</span>
+                  <select aria-label="Workflow" value={workflowId} onChange={(event) => setWorkflowId(event.target.value)}>
+                    {demoState.workflows.map((option) => (
+                      <option key={option.workflowId} value={option.workflowId}>
+                        {option.name}
+                      </option>
+                    ))}
+                  </select>
+                  <small>{workflow.description}</small>
+                </label>
+              )}
             </div>
             <div className="hero__status-grid">
               <article className="hero-signal hero-signal--live">
                 <span className="hero-signal__label">Live posture</span>
-                <strong>{titleCaseStatus(liveRun.status)}</strong>
-                <p>{liveRun.experimentLabel}</p>
+                <strong>{titleCaseStatus(selectedSystemSummary?.latestExecution?.status ?? liveRun.status)}</strong>
+                <p>{selectedControlPlaneSystem?.system.name ?? liveRun.experimentLabel}</p>
                 <div className="hero-signal__meta">
-                  <span>{formatCredits(liveRun.actualCredits)}</span>
-                  <span>{formatDuration(liveRun.durationMs)}</span>
+                  <span>{formatCredits(selectedSystemSummary?.avgCredits ?? liveRun.actualCredits)}</span>
+                  <span>{formatDuration(selectedSystemSummary?.avgDurationMs ?? liveRun.durationMs)}</span>
                 </div>
               </article>
               <article className="hero-signal hero-signal--replay">
                 <span className="hero-signal__label">Replay pressure</span>
-                <strong>{failedReplayStep?.title ?? 'No failing step'}</strong>
-                <p>{failedReplayStep?.error ?? failedReplayStep?.summary ?? 'The latest run is healthy.'}</p>
+                <strong>{pressureAgentLabel ?? failedReplayStep?.title ?? 'No failing step'}</strong>
+                <p>{failedReplayStep?.error ?? failedReplayStep?.summary ?? 'No active pressure point is recorded in the current system.'}</p>
                 <div className="hero-signal__meta">
                   <span>{titleCaseStatus(replayRun.status)}</span>
                   <span>{formatCredits(replayRun.actualCredits)}</span>
@@ -359,7 +440,35 @@ export function App() {
           </div>
         </header>
 
-        {showOnboarding ? <OnboardingPanel onDismiss={dismissOnboarding} /> : null}
+        {showOnboarding ? (
+          <OnboardingPanel
+            onDismiss={dismissOnboarding}
+            controlPlaneState={controlPlaneState}
+            systemState={selectedControlPlaneSystem}
+            runtimeLabel={selectedRuntime?.label ?? null}
+          />
+        ) : null}
+
+        {sortedSystems.length ? (
+          <SystemCatalogPanel
+            systems={sortedSystems}
+            selectedSystemId={selectedControlPlaneSystem?.system.systemId ?? null}
+            onSelectSystem={handleSystemChange}
+          />
+        ) : null}
+
+        {selectedControlPlaneSystem ? (
+          <section className="system-layout">
+            <AgentFleetPanel
+              systemState={selectedControlPlaneSystem}
+              selectedAgentId={selectedAgentId || null}
+              onSelectAgent={setSelectedAgentId}
+            />
+            <AgentDetailPanel systemState={selectedControlPlaneSystem} agentId={selectedAgentId || null} />
+          </section>
+        ) : null}
+
+        {selectedControlPlaneSystem ? <SystemPerformancePanel systemState={selectedControlPlaneSystem} /> : null}
 
         <section className="surface overview-panel">
           <div className="section-header">

--- a/apps/web/src/app/control-plane.test.ts
+++ b/apps/web/src/app/control-plane.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  filterAgentSummaries,
+  filterSystemStateByWindow,
+  summarizeAgents,
+  type ControlPlaneSystemState,
+} from './control-plane';
+
+const fixture: ControlPlaneSystemState = {
+  system: {
+    systemId: 'system_fixture',
+    workspaceId: 'workspace_fixture',
+    name: 'Fixture system',
+    runtimeIds: ['runtime_fixture'],
+  },
+  agents: [
+    {
+      agentId: 'agent_manager',
+      systemId: 'system_fixture',
+      runtimeId: 'runtime_fixture',
+      label: 'Manager',
+      kind: 'coordinator',
+      role: 'manager',
+      status: 'active',
+    },
+    {
+      agentId: 'agent_reviewer',
+      systemId: 'system_fixture',
+      runtimeId: 'runtime_fixture',
+      label: 'Reviewer',
+      kind: 'specialist',
+      role: 'reviewer',
+      status: 'active',
+    },
+  ],
+  topology: null,
+  executions: [
+    {
+      executionId: 'exec_latest',
+      systemId: 'system_fixture',
+      runtimeId: 'runtime_fixture',
+      traceId: 'trace_latest',
+      status: 'failed',
+      startedAt: '2026-04-22T12:00:00.000Z',
+      finishedAt: '2026-04-22T12:10:00.000Z',
+    },
+    {
+      executionId: 'exec_older',
+      systemId: 'system_fixture',
+      runtimeId: 'runtime_fixture',
+      traceId: 'trace_older',
+      status: 'succeeded',
+      startedAt: '2026-04-21T11:00:00.000Z',
+      finishedAt: '2026-04-21T11:05:00.000Z',
+    },
+  ],
+  executionSpans: {
+    exec_latest: [
+      {
+        spanId: 'span_latest_manager',
+        traceId: 'trace_latest',
+        executionId: 'exec_latest',
+        agentId: 'agent_manager',
+        name: 'Capture queue',
+        kind: 'capture',
+        status: 'succeeded',
+        startedAt: '2026-04-22T12:00:00.000Z',
+        finishedAt: '2026-04-22T12:02:00.000Z',
+      },
+      {
+        spanId: 'span_latest_reviewer',
+        traceId: 'trace_latest',
+        executionId: 'exec_latest',
+        agentId: 'agent_reviewer',
+        name: 'Review escalation',
+        kind: 'review',
+        status: 'failed',
+        startedAt: '2026-04-22T12:02:00.000Z',
+        finishedAt: '2026-04-22T12:10:00.000Z',
+      },
+    ],
+    exec_older: [
+      {
+        spanId: 'span_older_manager',
+        traceId: 'trace_older',
+        executionId: 'exec_older',
+        agentId: 'agent_manager',
+        name: 'Capture queue',
+        kind: 'capture',
+        status: 'succeeded',
+        startedAt: '2026-04-21T11:00:00.000Z',
+        finishedAt: '2026-04-21T11:02:00.000Z',
+      },
+    ],
+  },
+  executionMetrics: {
+    exec_latest: [
+      {
+        sampleId: 'metric_latest_credits',
+        metric: 'credits.actual',
+        unit: 'credits',
+        value: 11,
+        ts: '2026-04-22T12:10:00.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_latest',
+      },
+    ],
+    exec_older: [
+      {
+        sampleId: 'metric_older_credits',
+        metric: 'credits.actual',
+        unit: 'credits',
+        value: 5,
+        ts: '2026-04-21T11:05:00.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_older',
+      },
+    ],
+  },
+  interventions: [
+    {
+      interventionId: 'intervention_reviewer',
+      targetScopeType: 'agent',
+      targetScopeId: 'agent_reviewer',
+      actor: 'operator',
+      action: 'directive.review',
+      reason: 'Keep reviewer on a tighter path.',
+      requestedAt: '2026-04-22T12:12:00.000Z',
+      appliedAt: '2026-04-22T12:12:00.000Z',
+      status: 'applied',
+    },
+  ],
+  evaluations: [
+    {
+      evaluationId: 'evaluation_latest',
+      targetScopeType: 'system',
+      targetScopeId: 'system_fixture',
+      baselineRefs: ['exec_older'],
+      candidateRefs: ['exec_latest'],
+      verdict: 'hold',
+      createdAt: '2026-04-22T12:13:00.000Z',
+      summary: 'Hold until the reviewer stabilizes.',
+    },
+  ],
+  releases: [
+    {
+      releaseId: 'release_latest',
+      systemId: 'system_fixture',
+      candidateRef: 'exec_latest',
+      decision: 'hold',
+      requestedAt: '2026-04-22T12:14:00.000Z',
+      appliedAt: '2026-04-22T12:14:00.000Z',
+      status: 'applied',
+      summary: 'Release is still on hold.',
+    },
+  ],
+};
+
+describe('control-plane analytics helpers', () => {
+  it('filters a system state to the selected time window', () => {
+    const filtered = filterSystemStateByWindow(fixture, '24h');
+
+    expect(filtered?.executions).toHaveLength(1);
+    expect(filtered?.executions[0]?.executionId).toBe('exec_latest');
+    expect(Object.keys(filtered?.executionSpans ?? {})).toEqual(['exec_latest']);
+    expect(Object.keys(filtered?.executionMetrics ?? {})).toEqual(['exec_latest']);
+    expect(filtered?.evaluations).toHaveLength(1);
+    expect(filtered?.releases).toHaveLength(1);
+  });
+
+  it('filters agent summaries by attention focus', () => {
+    const summaries = summarizeAgents(fixture);
+    const attention = filterAgentSummaries(summaries, 'attention');
+    const failures = filterAgentSummaries(summaries, 'failures');
+    const directives = filterAgentSummaries(summaries, 'directives');
+
+    expect(attention.map((summary) => summary.agent.agentId)).toEqual(['agent_reviewer']);
+    expect(failures.map((summary) => summary.agent.agentId)).toEqual(['agent_reviewer']);
+    expect(directives.map((summary) => summary.agent.agentId)).toEqual(['agent_reviewer']);
+  });
+});

--- a/apps/web/src/app/control-plane.test.ts
+++ b/apps/web/src/app/control-plane.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  filterSystemSummaries,
   filterAgentSummaries,
   filterSystemStateByWindow,
+  summarizeFleet,
   summarizeAgents,
+  summarizeSystem,
   type ControlPlaneSystemState,
 } from './control-plane';
 
@@ -178,5 +181,22 @@ describe('control-plane analytics helpers', () => {
     expect(attention.map((summary) => summary.agent.agentId)).toEqual(['agent_reviewer']);
     expect(failures.map((summary) => summary.agent.agentId)).toEqual(['agent_reviewer']);
     expect(directives.map((summary) => summary.agent.agentId)).toEqual(['agent_reviewer']);
+  });
+
+  it('builds fleet summaries and attention filters for system comparison', () => {
+    const olderSystem = filterSystemStateByWindow(fixture, '24h');
+    const allSystems = [fixture, olderSystem ?? fixture];
+    const fleet = summarizeFleet(allSystems);
+    const healthyOnly = filterSystemSummaries(
+      allSystems
+        .map((systemState) => summarizeSystem(systemState))
+        .filter((summary): summary is NonNullable<ReturnType<typeof summarizeSystem>> => summary != null),
+      'healthy',
+    );
+
+    expect(fleet.systemCount).toBe(2);
+    expect(fleet.releaseWatchlist.length).toBeGreaterThan(0);
+    expect(fleet.hottestSystems[0]?.system.systemId).toBe('system_fixture');
+    expect(healthyOnly).toHaveLength(0);
   });
 });

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -38,10 +38,18 @@ export interface ControlPlaneSystemState {
   releases: ReleaseDecision[];
 }
 
+export interface ControlPlaneStorageInfo {
+  mode: 'memory' | 'file';
+  persistenceEnabled: boolean;
+  filePath: string | null;
+  detail: string;
+}
+
 export interface ControlPlaneState {
   runtimes: RuntimeRegistration[];
   systems: ControlPlaneSystemState[];
   systemsByWorkflowId: Record<string, ControlPlaneSystemState>;
+  storage: ControlPlaneStorageInfo;
 }
 
 export interface AgentSummary {
@@ -910,6 +918,18 @@ export async function loadControlPlaneState(options: LoadControlPlaneStateOption
   }
 
   const apiBaseUrl = options.apiBaseUrl ?? import.meta.env.VITE_API_URL ?? '';
+  const storagePayload = await fetchJson<{ item: ControlPlaneStorageInfo }>(
+    fetcher,
+    apiBaseUrl,
+    '/api/control/meta',
+  ).catch(() => ({
+    item: {
+      mode: 'memory' as const,
+      persistenceEnabled: false,
+      filePath: null,
+      detail: 'Ephemeral in-memory demo store.',
+    },
+  }));
   const runtimesPayload = await fetchJson<{ items: RuntimeRegistration[] }>(fetcher, apiBaseUrl, '/api/control/runtimes');
   const systemsPayload = await fetchJson<{ items: SystemDefinition[] }>(fetcher, apiBaseUrl, '/api/control/systems');
 
@@ -966,6 +986,7 @@ export async function loadControlPlaneState(options: LoadControlPlaneStateOption
     runtimes: runtimesPayload.items,
     systems,
     systemsByWorkflowId,
+    storage: storagePayload.item,
   };
 }
 

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -87,6 +87,7 @@ export interface SystemSummary {
 
 export type AnalyticsWindow = '24h' | '7d' | '30d' | 'all';
 export type AgentRosterFocus = 'all' | 'attention' | 'failures' | 'directives';
+export type SystemCatalogFocus = 'all' | 'attention' | 'active' | 'healthy';
 
 export interface SystemHistoryEvent {
   eventId: string;
@@ -118,6 +119,19 @@ export interface FleetAnalyticsSummary {
   recentFailures: SystemHistoryEvent[];
 }
 
+export interface FleetSummary {
+  systemCount: number;
+  activeSystemCount: number;
+  trackedAgentCount: number;
+  executionCount: number;
+  activeDirectiveCount: number;
+  avgSuccessRate: number;
+  avgCredits: number;
+  avgDurationMs: number;
+  hottestSystems: SystemSummary[];
+  releaseWatchlist: SystemSummary[];
+}
+
 export interface LoadControlPlaneStateOptions {
   apiBaseUrl?: string;
   fetch?: typeof globalThis.fetch;
@@ -146,6 +160,13 @@ export const ANALYTICS_WINDOW_OPTIONS: Array<{ id: AnalyticsWindow; label: strin
   { id: '7d', label: '7d' },
   { id: '30d', label: '30d' },
   { id: 'all', label: 'All time' },
+];
+
+export const SYSTEM_CATALOG_FOCUS_OPTIONS: Array<{ id: SystemCatalogFocus; label: string }> = [
+  { id: 'all', label: 'All systems' },
+  { id: 'attention', label: 'Needs attention' },
+  { id: 'active', label: 'Active now' },
+  { id: 'healthy', label: 'Healthy' },
 ];
 
 const ANALYTICS_WINDOW_MS: Record<Exclude<AnalyticsWindow, 'all'>, number> = {
@@ -1009,6 +1030,78 @@ export function summarizeSystem(systemState: ControlPlaneSystemState | null | un
     lastActiveAt: sortedExecutions[0]?.finishedAt ?? sortedExecutions[0]?.startedAt ?? null,
     pressureAgentId: agentSummaries[0]?.agent.agentId ?? null,
   };
+}
+
+export function summarizeFleet(systemStates: ControlPlaneSystemState[]): FleetSummary {
+  const summaries = systemStates
+    .map((systemState) => summarizeSystem(systemState))
+    .filter((summary): summary is SystemSummary => summary != null);
+
+  const hottestSystems = [...summaries]
+    .sort(
+      (left, right) =>
+        right.activeInterventionCount - left.activeInterventionCount ||
+        right.executionCount - left.executionCount ||
+        compareByNewest(left.lastActiveAt ?? undefined, right.lastActiveAt ?? undefined),
+    )
+    .slice(0, 3);
+
+  const releaseWatchlist = summaries
+    .filter((summary) => {
+      const releaseDecision = summary.latestRelease?.decision;
+      const evaluationVerdict = summary.latestEvaluation?.verdict;
+      return ['hold', 'rollback'].includes(releaseDecision ?? '') || ['hold', 'failed'].includes(evaluationVerdict ?? '');
+    })
+    .sort((left, right) =>
+      compareByNewest(
+        left.latestRelease?.appliedAt ?? left.latestRelease?.requestedAt ?? left.latestEvaluation?.createdAt,
+        right.latestRelease?.appliedAt ?? right.latestRelease?.requestedAt ?? right.latestEvaluation?.createdAt,
+      ),
+    )
+    .slice(0, 4);
+
+  return {
+    systemCount: summaries.length,
+    activeSystemCount: summaries.filter((summary) => summary.executionCount > 0).length,
+    trackedAgentCount: summaries.reduce((total, summary) => total + summary.agentCount, 0),
+    executionCount: summaries.reduce((total, summary) => total + summary.executionCount, 0),
+    activeDirectiveCount: summaries.reduce((total, summary) => total + summary.activeInterventionCount, 0),
+    avgSuccessRate: computeAverage(summaries.map((summary) => summary.successRate)),
+    avgCredits: computeAverage(summaries.map((summary) => summary.avgCredits)),
+    avgDurationMs: computeAverage(summaries.map((summary) => summary.avgDurationMs)),
+    hottestSystems,
+    releaseWatchlist,
+  };
+}
+
+export function filterSystemSummaries(summaries: SystemSummary[], focus: SystemCatalogFocus) {
+  switch (focus) {
+    case 'attention':
+      return summaries.filter(
+        (summary) =>
+          summary.activeInterventionCount > 0 ||
+          summary.latestExecution?.status === 'failed' ||
+          ['hold', 'rollback'].includes(summary.latestRelease?.decision ?? '') ||
+          ['hold', 'failed'].includes(summary.latestEvaluation?.verdict ?? ''),
+      );
+    case 'active':
+      return summaries.filter(
+        (summary) =>
+          summary.latestExecution?.status === 'running' ||
+          summary.latestExecution?.status === 'active' ||
+          summary.executionCount > 0,
+      );
+    case 'healthy':
+      return summaries.filter(
+        (summary) =>
+          summary.successRate >= 0.8 &&
+          summary.activeInterventionCount === 0 &&
+          !['hold', 'rollback'].includes(summary.latestRelease?.decision ?? ''),
+      );
+    case 'all':
+    default:
+      return summaries;
+  }
 }
 
 export function sortSystemsByActivity(systems: ControlPlaneSystemState[]): ControlPlaneSystemState[] {

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -39,9 +39,10 @@ export interface ControlPlaneSystemState {
 }
 
 export interface ControlPlaneStorageInfo {
-  mode: 'memory' | 'file';
+  mode: 'memory' | 'file' | 'blob';
   persistenceEnabled: boolean;
   filePath: string | null;
+  blobPath?: string | null;
   detail: string;
 }
 
@@ -927,6 +928,7 @@ export async function loadControlPlaneState(options: LoadControlPlaneStateOption
       mode: 'memory' as const,
       persistenceEnabled: false,
       filePath: null,
+      blobPath: null,
       detail: 'Ephemeral in-memory demo store.',
     },
   }));

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -1,16 +1,30 @@
 import type {
   AgentDefinition,
+  DirectiveMode,
   EvaluationRecord,
   ExecutionRecord,
   InterventionRecord,
   MetricDelta,
   MetricSample,
+  OperationalContext,
+  PhaseKind,
+  PolicySnapshot,
+  PromotionEvent,
+  Replay,
   ReleaseDecision,
+  RoleDirectiveMap,
+  Run,
+  RunStatus,
   RuntimeRegistration,
+  SavedPlan,
   SpanRecord,
+  StepExecution,
   SystemDefinition,
   TopologySnapshot,
+  Workflow,
+  WorkflowStep,
 } from '@agent-studio/contracts';
+import type { WorkflowDemoState } from './demo';
 
 export interface ControlPlaneSystemState {
   system: SystemDefinition;
@@ -85,6 +99,100 @@ export interface ControlPlaneImportBundle {
   releases?: ReleaseDecision[];
 }
 
+const DEFAULT_POLICY: PolicySnapshot = {
+  mode: 'recommended',
+  optimizationGoal: 'balanced',
+  reviewPolicy: 'standard',
+  maxElasticLanes: 1,
+};
+
+function formatTokenLabel(value: string) {
+  return value
+    .split(/[._\s-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+function toRoleSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function createSyntheticWorkflowId(systemId: string) {
+  return `system:${systemId}`;
+}
+
+function coercePhaseKind(value?: string): PhaseKind {
+  switch (value) {
+    case 'search':
+    case 'query':
+    case 'capture':
+    case 'analyze':
+    case 'summarize':
+    case 'deliver':
+    case 'note':
+      return value;
+    default:
+      return 'note';
+  }
+}
+
+function coerceRunStatus(value?: string): RunStatus {
+  switch (value) {
+    case 'planned':
+    case 'running':
+    case 'succeeded':
+    case 'failed':
+    case 'skipped':
+      return value;
+    case 'active':
+      return 'running';
+    default:
+      return 'planned';
+  }
+}
+
+function parseDirectiveMode(action?: string): DirectiveMode | undefined {
+  if (!action?.startsWith('directive.')) {
+    return undefined;
+  }
+
+  const mode = action.slice('directive.'.length);
+
+  if (mode === 'cheaper' || mode === 'review' || mode === 'promote') {
+    return mode;
+  }
+
+  return undefined;
+}
+
+function readMetadataRecord(metadata: unknown) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  return metadata as Record<string, unknown>;
+}
+
+function readMetadataString(metadata: unknown, key: string) {
+  const record = readMetadataRecord(metadata);
+  const value = record?.[key];
+
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readMetricValue(metrics: MetricSample[], metric: string) {
+  return metrics.find((sample) => sample.metric === metric)?.value;
+}
+
+function sortExecutionsByNewest(executions: ExecutionRecord[]) {
+  return [...executions].sort((left, right) => compareByNewest(left.finishedAt ?? left.startedAt, right.finishedAt ?? right.startedAt));
+}
+
 export function getExecutionForRun(systemState: ControlPlaneSystemState | null | undefined, runId: string) {
   if (!systemState) {
     return null;
@@ -150,6 +258,473 @@ export function getWorkflowIdForSystem(systemState: ControlPlaneSystemState | nu
   const workflowId = (metadata as Record<string, unknown>).workflowId;
 
   return typeof workflowId === 'string' && workflowId.trim().length > 0 ? workflowId : null;
+}
+
+function buildWorkflowSteps(systemState: ControlPlaneSystemState): WorkflowStep[] {
+  const topologyNodes = systemState.topology?.nodes ?? [];
+  const topologyEdges = systemState.topology?.edges ?? [];
+  const nodes =
+    topologyNodes.length > 0
+      ? topologyNodes.map((node) => ({
+          id: node.nodeId,
+          label: node.label,
+          role: node.role ?? systemState.agents.find((agent) => agent.agentId === node.agentId)?.role ?? toRoleSlug(node.label),
+          kind:
+            systemState.executionSpans &&
+            Object.values(systemState.executionSpans)
+              .flat()
+              .find((span) => span.nodeId === node.nodeId || (node.agentId && span.agentId === node.agentId))?.kind,
+          objective:
+            Object.values(systemState.executionSpans)
+              .flat()
+              .find((span) => span.nodeId === node.nodeId || (node.agentId && span.agentId === node.agentId))?.summary ??
+            `Track ${node.label} inside ${systemState.system.name}.`,
+          toolName: systemState.agents.find((agent) => agent.agentId === node.agentId)?.toolRefs?.[0],
+        }))
+      : systemState.agents.map((agent) => ({
+          id: agent.agentId,
+          label: agent.label,
+          role: agent.role ?? toRoleSlug(agent.label),
+          kind:
+            Object.values(systemState.executionSpans)
+              .flat()
+              .find((span) => span.agentId === agent.agentId)?.kind ??
+            agent.capabilities?.[0],
+          objective:
+            Object.values(systemState.executionSpans)
+              .flat()
+              .find((span) => span.agentId === agent.agentId)?.summary ??
+            `Track ${agent.label} inside ${systemState.system.name}.`,
+          toolName: agent.toolRefs?.[0],
+        }));
+
+  return nodes.map((node, index) => {
+    const dependsOnStepIds =
+      topologyEdges.length > 0
+        ? topologyEdges.filter((edge) => edge.targetNodeId === node.id).map((edge) => edge.sourceNodeId)
+        : index > 0
+          ? [nodes[index - 1].id]
+          : undefined;
+
+    return {
+      stepId: node.id,
+      kind: coercePhaseKind(node.kind),
+      title: node.label,
+      objective: node.objective,
+      assignedRole: node.role,
+      dependsOnStepIds: dependsOnStepIds?.length ? dependsOnStepIds : undefined,
+      toolName: node.toolName,
+    };
+  });
+}
+
+function buildSyntheticWorkflow(systemState: ControlPlaneSystemState): Workflow {
+  const workflowId = createSyntheticWorkflowId(systemState.system.systemId);
+
+  return {
+    workspaceId: systemState.system.workspaceId,
+    workflowId,
+    name: systemState.system.name,
+    description: systemState.system.description,
+    status: systemState.system.status ?? 'active',
+    createdAt: systemState.system.createdAt,
+    updatedAt: systemState.system.updatedAt,
+    steps: buildWorkflowSteps(systemState),
+    policy: DEFAULT_POLICY,
+  };
+}
+
+function buildRunFromExecution(workflowId: string, systemState: ControlPlaneSystemState, execution?: ExecutionRecord | null): Run {
+  if (!execution) {
+    const ts = systemState.system.updatedAt ?? systemState.system.createdAt ?? new Date().toISOString();
+
+    return {
+      runId: `run_${systemState.system.systemId}_pending`,
+      workflowId,
+      status: 'planned',
+      startedAt: ts,
+      experimentLabel: 'Awaiting first execution',
+    };
+  }
+
+  return {
+    runId: execution.runId ?? execution.executionId,
+    workflowId,
+    status: coerceRunStatus(execution.status),
+    startedAt: execution.startedAt,
+    finishedAt: execution.finishedAt,
+    actualCredits: readMetricValue(getExecutionMetrics(systemState, execution.executionId), 'credits.actual'),
+    durationMs: readMetricValue(getExecutionMetrics(systemState, execution.executionId), 'duration.ms'),
+    experimentLabel:
+      readMetadataString(execution.metadata, 'experimentLabel') ??
+      readMetadataString(execution.metadata, 'scenarioLabel') ??
+      `${systemState.system.name} ${formatTokenLabel(execution.status)}`,
+  };
+}
+
+function buildRoleDirectives(systemState: ControlPlaneSystemState): RoleDirectiveMap | undefined {
+  const directiveEntries: Array<[string, RoleDirectiveMap[string]]> = [];
+
+  systemState.interventions
+    .filter((intervention) => intervention.targetScopeType === 'agent')
+    .forEach((intervention) => {
+      const mode = parseDirectiveMode(intervention.action);
+      const agent = systemState.agents.find((item) => item.agentId === intervention.targetScopeId);
+      const role = agent?.role ?? toRoleSlug(agent?.label ?? intervention.targetScopeId);
+      const phases = readMetadataRecord(intervention.configPatch)?.phases;
+
+      if (!mode || !role) {
+        return;
+      }
+
+      directiveEntries.push([
+        role,
+        {
+          mode,
+          phases: Array.isArray(phases)
+            ? phases.filter((phase): phase is PhaseKind => typeof phase === 'string').map((phase) => coercePhaseKind(phase))
+            : undefined,
+          updatedAt: intervention.appliedAt ?? intervention.requestedAt,
+        },
+      ]);
+    });
+
+  const directives = Object.fromEntries(directiveEntries);
+
+  return Object.keys(directives).length ? directives : undefined;
+}
+
+function buildStepExecutions(systemState: ControlPlaneSystemState, workflow: Workflow, execution?: ExecutionRecord | null): StepExecution[] {
+  if (!execution) {
+    return workflow.steps.map((step) => ({
+      stepId: step.stepId,
+      kind: step.kind,
+      title: step.title,
+      assignedRole: step.assignedRole,
+      status: 'planned',
+      summary: `No execution has been recorded for ${step.title} yet.`,
+    }));
+  }
+
+  const spans = getExecutionSpans(systemState, execution.executionId);
+  if (!spans.length) {
+    return workflow.steps.map((step) => ({
+      stepId: step.stepId,
+      kind: step.kind,
+      title: step.title,
+      assignedRole: step.assignedRole,
+      status: coerceRunStatus(execution.status),
+      startedAt: execution.startedAt,
+      finishedAt: execution.finishedAt,
+      summary: `Execution ${execution.executionId} has no span breakdown yet.`,
+    }));
+  }
+
+  return spans.map((span) => {
+    const agent = span.agentId ? systemState.agents.find((item) => item.agentId === span.agentId) : undefined;
+    const latestDirective =
+      span.agentId != null
+        ? systemState.interventions
+            .filter((intervention) => intervention.targetScopeType === 'agent' && intervention.targetScopeId === span.agentId)
+            .sort((left, right) => compareByNewest(left.appliedAt ?? left.requestedAt, right.appliedAt ?? right.requestedAt))[0]
+        : undefined;
+    const directivePhases = readMetadataRecord(latestDirective?.configPatch)?.phases;
+
+    return {
+      stepId: span.nodeId ?? span.agentId ?? span.spanId,
+      kind: coercePhaseKind(span.kind),
+      title: span.name,
+      assignedRole: agent?.role ?? toRoleSlug(agent?.label ?? span.name),
+      status: coerceRunStatus(span.status),
+      startedAt: span.startedAt,
+      finishedAt: span.finishedAt,
+      durationMs: span.usage?.durationMs,
+      actualCredits: span.usage?.credits,
+      tokenUsage:
+        span.usage?.inputTokens != null || span.usage?.outputTokens != null || span.usage?.totalTokens != null
+          ? {
+              inputTokens: span.usage?.inputTokens,
+              outputTokens: span.usage?.outputTokens,
+              totalTokens: span.usage?.totalTokens,
+            }
+          : undefined,
+      toolCalls: span.usage?.toolCalls,
+      directiveMode: parseDirectiveMode(latestDirective?.action),
+      directivePhases: Array.isArray(directivePhases)
+        ? directivePhases.filter((phase): phase is PhaseKind => typeof phase === 'string').map((phase) => coercePhaseKind(phase))
+        : undefined,
+      summary: span.summary ?? `Execution span for ${span.name}.`,
+      error: span.status === 'failed' ? span.summary ?? `${span.name} failed.` : undefined,
+    };
+  });
+}
+
+function buildHealthyComparison(
+  workflowId: string,
+  selectedRun: Run,
+  baselineRun: Run | null,
+): OperationalContext['lastHealthyComparison'] | undefined {
+  if (!baselineRun || baselineRun.runId === selectedRun.runId) {
+    return undefined;
+  }
+
+  const creditsDelta =
+    selectedRun.actualCredits != null && baselineRun.actualCredits != null ? selectedRun.actualCredits - baselineRun.actualCredits : undefined;
+  const durationDelta =
+    selectedRun.durationMs != null && baselineRun.durationMs != null ? selectedRun.durationMs - baselineRun.durationMs : undefined;
+
+  const changedSignals = [
+    creditsDelta != null && creditsDelta !== 0 ? `Spend shifted by ${creditsDelta > 0 ? '+' : ''}${creditsDelta} credits` : null,
+    durationDelta != null && durationDelta !== 0 ? `Duration shifted by ${Math.round(durationDelta / 1000)} seconds` : null,
+    selectedRun.status !== baselineRun.status ? `Status changed from ${baselineRun.status} to ${selectedRun.status}` : null,
+  ].filter((value): value is string => value != null);
+
+  return {
+    runId: baselineRun.runId,
+    label: baselineRun.experimentLabel ?? baselineRun.runId,
+    startedAt: baselineRun.startedAt,
+    finishedAt: baselineRun.finishedAt,
+    creditsDelta,
+    durationDelta,
+    changedSignals,
+    summary:
+      changedSignals[0] ??
+      `Using ${baselineRun.experimentLabel ?? baselineRun.runId} as the nearest healthy comparison for ${selectedRun.experimentLabel ?? selectedRun.runId}.`,
+  };
+}
+
+function buildSimilarRuns(executions: ExecutionRecord[], selectedRun: Run, workflowId: string, systemState: ControlPlaneSystemState) {
+  return sortExecutionsByNewest(executions)
+    .filter((execution) => (execution.runId ?? execution.executionId) !== selectedRun.runId)
+    .slice(0, 3)
+    .map((execution) => {
+      const comparedRun = buildRunFromExecution(workflowId, systemState, execution);
+      const matchedSignals = [
+        comparedRun.status === selectedRun.status ? `Both runs ended ${selectedRun.status}` : `Status diverged from ${selectedRun.status}`,
+        comparedRun.actualCredits != null && selectedRun.actualCredits != null
+          ? `Spend delta ${comparedRun.actualCredits - selectedRun.actualCredits > 0 ? '+' : ''}${(comparedRun.actualCredits - selectedRun.actualCredits).toFixed(0)}`
+          : 'Metric comparison pending',
+      ];
+
+      return {
+        runId: comparedRun.runId,
+        label: comparedRun.experimentLabel ?? comparedRun.runId,
+        status: comparedRun.status,
+        startedAt: comparedRun.startedAt,
+        finishedAt: comparedRun.finishedAt,
+        actualCredits: comparedRun.actualCredits,
+        durationMs: comparedRun.durationMs,
+        similarityScore: comparedRun.status === selectedRun.status ? 0.86 : 0.62,
+        matchedSignals,
+      };
+    });
+}
+
+function buildRecommendationEvidence(systemState: ControlPlaneSystemState, execution: ExecutionRecord | null | undefined, run: Run) {
+  const spans = execution ? getExecutionSpans(systemState, execution.executionId) : [];
+  const failedSpan = spans.find((span) => span.status === 'failed') ?? null;
+  const latestIntervention = systemState.interventions[0] ?? null;
+  const latestEvaluation = getLatestEvaluation(systemState);
+  const latestRelease = getLatestReleaseDecision(systemState);
+
+  const evidence = [
+    failedSpan
+      ? {
+          evidenceId: `evidence_${failedSpan.spanId}`,
+          title: `${failedSpan.name} is the current break`,
+          body: failedSpan.summary ?? `${failedSpan.name} failed inside the current execution trace.`,
+          sourceLabel: run.experimentLabel ?? run.runId,
+          phase: coercePhaseKind(failedSpan.kind),
+          relatedRunIds: [run.runId],
+        }
+      : null,
+    latestIntervention
+      ? {
+          evidenceId: latestIntervention.interventionId,
+          title: formatTokenLabel(latestIntervention.action),
+          body: latestIntervention.reason,
+          sourceLabel: 'Latest intervention',
+          relatedRunIds: latestIntervention.relatedTraceId ? [latestIntervention.relatedTraceId] : undefined,
+        }
+      : null,
+    latestEvaluation
+      ? {
+          evidenceId: latestEvaluation.evaluationId,
+          title: `${formatTokenLabel(latestEvaluation.verdict)} evaluation`,
+          body: latestEvaluation.summary ?? 'Latest evaluation imported into the control plane.',
+          sourceLabel: 'Latest evaluation',
+          relatedRunIds: [...latestEvaluation.baselineRefs, ...latestEvaluation.candidateRefs],
+        }
+      : null,
+    latestRelease
+      ? {
+          evidenceId: latestRelease.releaseId,
+          title: `${formatTokenLabel(latestRelease.decision)} release`,
+          body: latestRelease.summary ?? 'Latest release decision imported into the control plane.',
+          sourceLabel: 'Latest release',
+          relatedRunIds: [latestRelease.candidateRef, latestRelease.baselineRef].filter((value): value is string => Boolean(value)),
+        }
+      : null,
+  ].filter((item): item is NonNullable<typeof item> => item != null);
+
+  return evidence.length
+    ? evidence
+    : [
+        {
+          evidenceId: `evidence_${systemState.system.systemId}_pending`,
+          title: 'Import more execution evidence',
+          body: 'This system has enough registry data to render, but Replay and Optimize will get stronger once more spans, evaluations, and releases land.',
+          sourceLabel: 'System registry',
+          relatedRunIds: [run.runId],
+        },
+      ];
+}
+
+function buildReplayFromExecution(
+  systemState: ControlPlaneSystemState,
+  workflow: Workflow,
+  run: Run,
+  baselineRun: Run | null,
+  execution?: ExecutionRecord | null,
+): Replay {
+  return {
+    workflow,
+    run,
+    policy: workflow.policy,
+    stepExecutions: buildStepExecutions(systemState, workflow, execution),
+    studioState: {
+      roleDirectives: buildRoleDirectives(systemState),
+      promotionHistory: buildPromotionHistory(systemState),
+      savedPlans: buildSavedPlans(systemState, workflow),
+    },
+    operationalContext: {
+      workflowId: workflow.workflowId,
+      runId: run.runId,
+      generatedAt: execution?.finishedAt ?? execution?.startedAt ?? run.startedAt,
+      similarRuns: buildSimilarRuns(systemState.executions, run, workflow.workflowId, systemState),
+      lastHealthyComparison: buildHealthyComparison(workflow.workflowId, run, baselineRun),
+      recommendationEvidence: buildRecommendationEvidence(systemState, execution, run),
+    },
+  };
+}
+
+function buildSavedPlans(systemState: ControlPlaneSystemState, workflow: Workflow): SavedPlan[] {
+  const latestEvaluation = getLatestEvaluation(systemState);
+  const latestRelease = getLatestReleaseDecision(systemState);
+  const roleDirectives = buildRoleDirectives(systemState);
+  const createdAt =
+    latestRelease?.appliedAt ??
+    latestRelease?.requestedAt ??
+    latestEvaluation?.createdAt ??
+    systemState.system.updatedAt ??
+    systemState.system.createdAt ??
+    new Date().toISOString();
+
+  if (!latestEvaluation && !latestRelease && !roleDirectives) {
+    return [];
+  }
+
+  return [
+    {
+      id:
+        readMetadataString(latestEvaluation?.metadata, 'candidatePlanId') ??
+        latestRelease?.candidateRef ??
+        `plan_${systemState.system.systemId}_current`,
+      name: latestRelease ? `${formatTokenLabel(latestRelease.decision)} candidate` : 'Control-plane candidate',
+      createdAt,
+      scenarioId: workflow.workflowId,
+      previewPresetId: 'control-plane',
+      executionPolicy: workflow.policy ?? DEFAULT_POLICY,
+      roleDirectives,
+      notes: latestEvaluation?.summary ?? latestRelease?.summary ?? `Current saved plan derived from ${systemState.system.name}.`,
+    },
+  ];
+}
+
+function buildPromotionHistory(systemState: ControlPlaneSystemState): PromotionEvent[] {
+  return [...systemState.releases]
+    .sort((left, right) => compareByNewest(left.appliedAt ?? left.requestedAt, right.appliedAt ?? right.requestedAt))
+    .map((release) => {
+      const metadata = readMetadataRecord(release.metadata);
+
+      return {
+        eventId: release.releaseId,
+        appliedAt: release.appliedAt ?? release.requestedAt,
+        mode: release.decision === 'rollback' ? 'rollback' : 'graduation',
+        summary: release.summary ?? `${formatTokenLabel(release.decision)} release applied to ${systemState.system.name}.`,
+        sourceExperimentId: release.evidenceRefs?.[0],
+        planId: release.candidateRef,
+        confidence: typeof metadata?.confidence === 'number' ? metadata.confidence : undefined,
+        successDelta: typeof metadata?.successDelta === 'number' ? metadata.successDelta : undefined,
+        creditsDelta: typeof metadata?.creditsDelta === 'number' ? metadata.creditsDelta : undefined,
+        durationDelta: typeof metadata?.durationDelta === 'number' ? metadata.durationDelta : undefined,
+      };
+    });
+}
+
+export function buildSystemWorkflowState(systemState: ControlPlaneSystemState | null | undefined): WorkflowDemoState | null {
+  if (!systemState) {
+    return null;
+  }
+
+  const workflow = buildSyntheticWorkflow(systemState);
+  const sortedExecutions = sortExecutionsByNewest(systemState.executions);
+  const liveExecution = sortedExecutions[0] ?? null;
+  const replayExecution = sortedExecutions.find((execution) => coerceRunStatus(execution.status) === 'failed') ?? liveExecution;
+  const candidateExecution =
+    (getLatestReleaseDecision(systemState)?.candidateRef
+      ? sortedExecutions.find(
+          (execution) =>
+            execution.executionId === getLatestReleaseDecision(systemState)?.candidateRef ||
+            execution.runId === getLatestReleaseDecision(systemState)?.candidateRef,
+        ) ?? null
+      : null) ??
+    liveExecution;
+
+  const liveRun = buildRunFromExecution(workflow.workflowId, systemState, liveExecution);
+  const replayRun = buildRunFromExecution(workflow.workflowId, systemState, replayExecution);
+  const candidateRun = buildRunFromExecution(workflow.workflowId, systemState, candidateExecution);
+
+  const latestSuccessfulExecution =
+    sortedExecutions.find(
+      (execution) =>
+        coerceRunStatus(execution.status) === 'succeeded' &&
+        (execution.runId ?? execution.executionId) !== replayRun.runId &&
+        (execution.runId ?? execution.executionId) !== candidateRun.runId,
+    ) ??
+    sortedExecutions.find((execution) => coerceRunStatus(execution.status) === 'succeeded') ??
+    candidateExecution ??
+    replayExecution;
+
+  const baselineRun = buildRunFromExecution(workflow.workflowId, systemState, latestSuccessfulExecution);
+  const savedPlans = buildSavedPlans(systemState, workflow);
+  const promotionHistory = buildPromotionHistory(systemState);
+
+  return {
+    workflow,
+    runsByNewest: sortedExecutions.map((execution) => buildRunFromExecution(workflow.workflowId, systemState, execution)),
+    live: {
+      run: liveRun,
+      replay: buildReplayFromExecution(systemState, workflow, liveRun, baselineRun, liveExecution),
+    },
+    replay: {
+      run: replayRun,
+      replay: buildReplayFromExecution(systemState, workflow, replayRun, baselineRun, replayExecution),
+      baselineRun,
+    },
+    optimize: {
+      baselineRun,
+      candidateRun,
+      candidateReplay: buildReplayFromExecution(systemState, workflow, candidateRun, baselineRun, candidateExecution),
+      candidatePlan: savedPlans[0] ?? null,
+      promotionHistory,
+      promotionSummary:
+        getLatestReleaseDecision(systemState)?.summary ??
+        getLatestEvaluation(systemState)?.summary ??
+        promotionHistory[0]?.summary ??
+        `Imported release evidence for ${systemState.system.name}.`,
+    },
+  };
 }
 
 function compareByNewest(left?: string, right?: string) {

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -30,6 +30,38 @@ export interface ControlPlaneState {
   systemsByWorkflowId: Record<string, ControlPlaneSystemState>;
 }
 
+export interface AgentSummary {
+  agent: AgentDefinition;
+  spanCount: number;
+  failedSpanCount: number;
+  successRate: number;
+  avgDurationMs: number;
+  avgCredits: number;
+  totalCredits: number;
+  interventionCount: number;
+  activeInterventionCount: number;
+  lastActiveAt: string | null;
+  latestSpan: SpanRecord | null;
+  latestIntervention: InterventionRecord | null;
+  pressureScore: number;
+}
+
+export interface SystemSummary {
+  system: SystemDefinition;
+  latestExecution: ExecutionRecord | null;
+  latestEvaluation: EvaluationRecord | null;
+  latestRelease: ReleaseDecision | null;
+  agentCount: number;
+  executionCount: number;
+  interventionCount: number;
+  activeInterventionCount: number;
+  successRate: number;
+  avgDurationMs: number;
+  avgCredits: number;
+  lastActiveAt: string | null;
+  pressureAgentId: string | null;
+}
+
 export interface LoadControlPlaneStateOptions {
   apiBaseUrl?: string;
   fetch?: typeof globalThis.fetch;
@@ -89,6 +121,137 @@ export function getMetricDelta(evaluation: EvaluationRecord | null | undefined, 
   }
 
   return evaluation.metricDeltas.find((item) => item.metric === metric) ?? null;
+}
+
+export function getWorkflowIdForSystem(systemState: ControlPlaneSystemState | null | undefined) {
+  const metadata = systemState?.system.metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const workflowId = (metadata as Record<string, unknown>).workflowId;
+
+  return typeof workflowId === 'string' && workflowId.trim().length > 0 ? workflowId : null;
+}
+
+function compareByNewest(left?: string, right?: string) {
+  if (left && right) {
+    return new Date(right).getTime() - new Date(left).getTime();
+  }
+
+  if (right) {
+    return 1;
+  }
+
+  if (left) {
+    return -1;
+  }
+
+  return 0;
+}
+
+function computeAverage(values: number[]) {
+  if (!values.length) {
+    return 0;
+  }
+
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+export function summarizeAgent(systemState: ControlPlaneSystemState | null | undefined, agentId: string): AgentSummary | null {
+  if (!systemState) {
+    return null;
+  }
+
+  const agent = systemState.agents.find((item) => item.agentId === agentId);
+  if (!agent) {
+    return null;
+  }
+
+  const spans = Object.values(systemState.executionSpans)
+    .flat()
+    .filter((span) => span.agentId === agentId)
+    .sort((left, right) => compareByNewest(left.finishedAt ?? left.startedAt, right.finishedAt ?? right.startedAt));
+  const interventions = systemState.interventions
+    .filter((intervention) => intervention.targetScopeType === 'agent' && intervention.targetScopeId === agentId)
+    .sort((left, right) => compareByNewest(left.appliedAt ?? left.requestedAt, right.appliedAt ?? right.requestedAt));
+  const durationValues = spans.map((span) => span.usage?.durationMs).filter((value): value is number => value != null);
+  const creditValues = spans.map((span) => span.usage?.credits).filter((value): value is number => value != null);
+  const failedSpanCount = spans.filter((span) => span.status === 'failed').length;
+  const successRate = spans.length ? (spans.length - failedSpanCount) / spans.length : 1;
+  const avgDurationMs = computeAverage(durationValues);
+  const avgCredits = computeAverage(creditValues);
+  const totalCredits = creditValues.reduce((total, value) => total + value, 0);
+  const activeInterventionCount = interventions.filter((intervention) => intervention.status === 'applied').length;
+  const pressureScore = failedSpanCount * 4 + activeInterventionCount * 2 + Math.round(avgDurationMs / 1000);
+
+  return {
+    agent,
+    spanCount: spans.length,
+    failedSpanCount,
+    successRate,
+    avgDurationMs,
+    avgCredits,
+    totalCredits,
+    interventionCount: interventions.length,
+    activeInterventionCount,
+    lastActiveAt: spans[0]?.finishedAt ?? spans[0]?.startedAt ?? null,
+    latestSpan: spans[0] ?? null,
+    latestIntervention: interventions[0] ?? null,
+    pressureScore,
+  };
+}
+
+export function summarizeAgents(systemState: ControlPlaneSystemState | null | undefined): AgentSummary[] {
+  if (!systemState) {
+    return [];
+  }
+
+  return systemState.agents
+    .map((agent) => summarizeAgent(systemState, agent.agentId))
+    .filter((summary): summary is AgentSummary => summary != null)
+    .sort((left, right) => right.pressureScore - left.pressureScore || compareByNewest(left.lastActiveAt ?? undefined, right.lastActiveAt ?? undefined));
+}
+
+export function summarizeSystem(systemState: ControlPlaneSystemState | null | undefined): SystemSummary | null {
+  if (!systemState) {
+    return null;
+  }
+
+  const sortedExecutions = [...systemState.executions].sort((left, right) =>
+    compareByNewest(left.finishedAt ?? left.startedAt, right.finishedAt ?? right.startedAt),
+  );
+  const executionMetrics = Object.values(systemState.executionMetrics).flat();
+  const durationSamples = executionMetrics.filter((sample) => sample.metric === 'duration.ms' && sample.scopeType === 'execution');
+  const creditSamples = executionMetrics.filter((sample) => sample.metric === 'credits.actual' && sample.scopeType === 'execution');
+  const agentSummaries = summarizeAgents(systemState);
+
+  return {
+    system: systemState.system,
+    latestExecution: sortedExecutions[0] ?? null,
+    latestEvaluation: getLatestEvaluation(systemState),
+    latestRelease: getLatestReleaseDecision(systemState),
+    agentCount: systemState.agents.length,
+    executionCount: systemState.executions.length,
+    interventionCount: systemState.interventions.length,
+    activeInterventionCount: systemState.interventions.filter((intervention) => intervention.status === 'applied').length,
+    successRate: sortedExecutions.length
+      ? sortedExecutions.filter((execution) => execution.status === 'succeeded').length / sortedExecutions.length
+      : 1,
+    avgDurationMs: computeAverage(durationSamples.map((sample) => sample.value)),
+    avgCredits: computeAverage(creditSamples.map((sample) => sample.value)),
+    lastActiveAt: sortedExecutions[0]?.finishedAt ?? sortedExecutions[0]?.startedAt ?? null,
+    pressureAgentId: agentSummaries[0]?.agent.agentId ?? null,
+  };
+}
+
+export function sortSystemsByActivity(systems: ControlPlaneSystemState[]): ControlPlaneSystemState[] {
+  return [...systems].sort((left, right) => {
+    const leftSummary = summarizeSystem(left);
+    const rightSummary = summarizeSystem(right);
+
+    return compareByNewest(leftSummary?.lastActiveAt ?? undefined, rightSummary?.lastActiveAt ?? undefined);
+  });
 }
 
 function buildApiUrl(apiBaseUrl: string, pathname: string) {

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -85,6 +85,33 @@ export interface SystemSummary {
   pressureAgentId: string | null;
 }
 
+export interface SystemHistoryEvent {
+  eventId: string;
+  kind: 'execution' | 'directive' | 'evaluation' | 'release';
+  occurredAt: string;
+  status: string;
+  title: string;
+  summary: string;
+  relatedAgentId: string | null;
+  relatedExecutionId: string | null;
+}
+
+export interface FleetAnalyticsSummary {
+  executionStatusCounts: {
+    running: number;
+    succeeded: number;
+    failed: number;
+  };
+  totalSpans: number;
+  failedSpans: number;
+  activeDirectives: number;
+  recentEventCount24h: number;
+  recentEventCount7d: number;
+  latestEventAt: string | null;
+  hottestAgents: AgentSummary[];
+  recentFailures: SystemHistoryEvent[];
+}
+
 export interface LoadControlPlaneStateOptions {
   apiBaseUrl?: string;
   fetch?: typeof globalThis.fetch;
@@ -760,6 +787,14 @@ function computeAverage(values: number[]) {
   return values.reduce((total, value) => total + value, 0) / values.length;
 }
 
+function isWithinWindow(timestamp: string | null | undefined, windowMs: number) {
+  if (!timestamp) {
+    return false;
+  }
+
+  return Date.now() - new Date(timestamp).getTime() <= windowMs;
+}
+
 export function summarizeAgent(systemState: ControlPlaneSystemState | null | undefined, agentId: string): AgentSummary | null {
   if (!systemState) {
     return null;
@@ -854,6 +889,104 @@ export function sortSystemsByActivity(systems: ControlPlaneSystemState[]): Contr
 
     return compareByNewest(leftSummary?.lastActiveAt ?? undefined, rightSummary?.lastActiveAt ?? undefined);
   });
+}
+
+export function buildSystemHistoryEvents(systemState: ControlPlaneSystemState | null | undefined): SystemHistoryEvent[] {
+  if (!systemState) {
+    return [];
+  }
+
+  const executionEvents = systemState.executions.map((execution) => {
+    const metrics = systemState.executionMetrics[execution.executionId] ?? [];
+    const credits = readMetricValue(metrics, 'credits.actual');
+    const durationMs = readMetricValue(metrics, 'duration.ms');
+    const experimentLabel =
+      readMetadataString(execution.metadata, 'experimentLabel') ??
+      readMetadataString(execution.metadata, 'label') ??
+      execution.runId ??
+      execution.executionId;
+
+    return {
+      eventId: execution.executionId,
+      kind: 'execution' as const,
+      occurredAt: execution.finishedAt ?? execution.startedAt,
+      status: execution.status,
+      title: `${formatTokenLabel(execution.status)} execution · ${experimentLabel}`,
+      summary: `${systemState.system.name} consumed ${credits?.toFixed(0) ?? '—'} credits over ${durationMs ? Math.round(durationMs / 1000) : '0'}s.`,
+      relatedAgentId: null,
+      relatedExecutionId: execution.executionId,
+    };
+  });
+
+  const directiveEvents = systemState.interventions.map((intervention) => ({
+    eventId: intervention.interventionId,
+    kind: 'directive' as const,
+    occurredAt: intervention.appliedAt ?? intervention.requestedAt,
+    status: intervention.status ?? 'recorded',
+    title: `${formatTokenLabel(intervention.action.replace(/\./g, ' '))} · ${
+      intervention.targetScopeType === 'agent'
+        ? getAgentLabel(systemState, intervention.targetScopeId) ?? intervention.targetScopeId
+        : systemState.system.name
+    }`,
+    summary: intervention.reason ?? 'Directive intervention recorded without a written reason.',
+    relatedAgentId: intervention.targetScopeType === 'agent' ? intervention.targetScopeId : null,
+    relatedExecutionId: null,
+  }));
+
+  const evaluationEvents = systemState.evaluations.map((evaluation) => ({
+    eventId: evaluation.evaluationId,
+    kind: 'evaluation' as const,
+    occurredAt: evaluation.createdAt,
+    status: evaluation.verdict,
+    title: `Evaluation · ${formatTokenLabel(evaluation.verdict)}`,
+    summary: evaluation.summary ?? 'Evaluation recorded without a summary.',
+    relatedAgentId: null,
+    relatedExecutionId: evaluation.candidateRefs?.[0] ?? null,
+  }));
+
+  const releaseEvents = systemState.releases.map((release) => ({
+    eventId: release.releaseId,
+    kind: 'release' as const,
+    occurredAt: release.appliedAt ?? release.requestedAt,
+    status: release.decision,
+    title: `Release · ${formatTokenLabel(release.decision)}`,
+    summary: release.summary ?? 'Release decision recorded without a summary.',
+    relatedAgentId: null,
+    relatedExecutionId: release.candidateRef ?? null,
+  }));
+
+  return [...executionEvents, ...directiveEvents, ...evaluationEvents, ...releaseEvents].sort((left, right) =>
+    compareByNewest(left.occurredAt, right.occurredAt),
+  );
+}
+
+export function summarizeFleetAnalytics(systemState: ControlPlaneSystemState | null | undefined): FleetAnalyticsSummary | null {
+  if (!systemState) {
+    return null;
+  }
+
+  const spans = Object.values(systemState.executionSpans).flat();
+  const history = buildSystemHistoryEvents(systemState);
+  const hottestAgents = summarizeAgents(systemState).slice(0, 3);
+  const recentFailures = history.filter((event) =>
+    ['failed', 'hold', 'rollback'].includes(event.status),
+  );
+
+  return {
+    executionStatusCounts: {
+      running: systemState.executions.filter((execution) => execution.status === 'running').length,
+      succeeded: systemState.executions.filter((execution) => execution.status === 'succeeded').length,
+      failed: systemState.executions.filter((execution) => execution.status === 'failed').length,
+    },
+    totalSpans: spans.length,
+    failedSpans: spans.filter((span) => span.status === 'failed').length,
+    activeDirectives: systemState.interventions.filter((intervention) => intervention.status === 'applied').length,
+    recentEventCount24h: history.filter((event) => isWithinWindow(event.occurredAt, 24 * 60 * 60 * 1000)).length,
+    recentEventCount7d: history.filter((event) => isWithinWindow(event.occurredAt, 7 * 24 * 60 * 60 * 1000)).length,
+    latestEventAt: history[0]?.occurredAt ?? null,
+    hottestAgents,
+    recentFailures: recentFailures.slice(0, 4),
+  };
 }
 
 function buildApiUrl(apiBaseUrl: string, pathname: string) {

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -3,6 +3,7 @@ import type {
   EvaluationRecord,
   ExecutionRecord,
   InterventionRecord,
+  MetricDelta,
   MetricSample,
   ReleaseDecision,
   RuntimeRegistration,
@@ -64,6 +65,30 @@ export function getAgentLabel(systemState: ControlPlaneSystemState | null | unde
   }
 
   return systemState.agents.find((agent) => agent.agentId === agentId)?.label ?? null;
+}
+
+export function getLatestEvaluation(systemState: ControlPlaneSystemState | null | undefined) {
+  if (!systemState) {
+    return null;
+  }
+
+  return systemState.evaluations[0] ?? null;
+}
+
+export function getLatestReleaseDecision(systemState: ControlPlaneSystemState | null | undefined) {
+  if (!systemState) {
+    return null;
+  }
+
+  return systemState.releases[0] ?? null;
+}
+
+export function getMetricDelta(evaluation: EvaluationRecord | null | undefined, metric: string): MetricDelta | null {
+  if (!evaluation?.metricDeltas?.length) {
+    return null;
+  }
+
+  return evaluation.metricDeltas.find((item) => item.metric === metric) ?? null;
 }
 
 function buildApiUrl(apiBaseUrl: string, pathname: string) {

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -67,6 +67,24 @@ export interface LoadControlPlaneStateOptions {
   fetch?: typeof globalThis.fetch;
 }
 
+export interface IngestControlPlaneOptions {
+  apiBaseUrl?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface ControlPlaneImportBundle {
+  runtimes?: RuntimeRegistration[];
+  systems?: SystemDefinition[];
+  agents?: AgentDefinition[];
+  topologies?: TopologySnapshot[];
+  executions?: ExecutionRecord[];
+  spans?: SpanRecord[];
+  metrics?: MetricSample[];
+  interventions?: InterventionRecord[];
+  evaluations?: EvaluationRecord[];
+  releases?: ReleaseDecision[];
+}
+
 export function getExecutionForRun(systemState: ControlPlaneSystemState | null | undefined, runId: string) {
   if (!systemState) {
     return null;
@@ -276,6 +294,29 @@ async function fetchJson<T>(fetcher: typeof globalThis.fetch, apiBaseUrl: string
   return (await response.json()) as T;
 }
 
+async function postJson<TInput, TOutput>(
+  fetcher: typeof globalThis.fetch,
+  apiBaseUrl: string,
+  pathname: string,
+  payload: TInput,
+): Promise<TOutput> {
+  const response = await fetcher(buildApiUrl(apiBaseUrl, pathname), {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text().catch(() => '');
+    throw new Error(message || `Failed to POST ${pathname} (${response.status}).`);
+  }
+
+  return (await response.json()) as TOutput;
+}
+
 function readWorkflowId(system: SystemDefinition) {
   const metadata = system.metadata;
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
@@ -351,4 +392,45 @@ export async function loadControlPlaneState(options: LoadControlPlaneStateOption
     systems,
     systemsByWorkflowId,
   };
+}
+
+export async function ingestControlPlaneItems<T>(
+  pathname: string,
+  payload: T | T[],
+  options: IngestControlPlaneOptions = {},
+): Promise<void> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  if (!fetcher) {
+    throw new Error('Fetch is not available in this environment.');
+  }
+
+  const apiBaseUrl = options.apiBaseUrl ?? import.meta.env.VITE_API_URL ?? '';
+
+  await postJson(fetcher, apiBaseUrl, pathname, payload);
+}
+
+export async function ingestControlPlaneBundle(
+  bundle: ControlPlaneImportBundle,
+  options: IngestControlPlaneOptions = {},
+): Promise<void> {
+  const orderedWrites: Array<[string, unknown[] | undefined]> = [
+    ['/api/control/ingest/runtimes', bundle.runtimes],
+    ['/api/control/ingest/systems', bundle.systems],
+    ['/api/control/ingest/agents', bundle.agents],
+    ['/api/control/ingest/topologies', bundle.topologies],
+    ['/api/control/ingest/executions', bundle.executions],
+    ['/api/control/ingest/spans', bundle.spans],
+    ['/api/control/ingest/metrics', bundle.metrics],
+    ['/api/control/ingest/interventions', bundle.interventions],
+    ['/api/control/ingest/evaluations', bundle.evaluations],
+    ['/api/control/ingest/releases', bundle.releases],
+  ];
+
+  for (const [pathname, items] of orderedWrites) {
+    if (!items?.length) {
+      continue;
+    }
+
+    await ingestControlPlaneItems(pathname, items, options);
+  }
 }

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -85,6 +85,9 @@ export interface SystemSummary {
   pressureAgentId: string | null;
 }
 
+export type AnalyticsWindow = '24h' | '7d' | '30d' | 'all';
+export type AgentRosterFocus = 'all' | 'attention' | 'failures' | 'directives';
+
 export interface SystemHistoryEvent {
   eventId: string;
   kind: 'execution' | 'directive' | 'evaluation' | 'release';
@@ -97,6 +100,7 @@ export interface SystemHistoryEvent {
 }
 
 export interface FleetAnalyticsSummary {
+  executionCount: number;
   executionStatusCounts: {
     running: number;
     succeeded: number;
@@ -105,8 +109,10 @@ export interface FleetAnalyticsSummary {
   totalSpans: number;
   failedSpans: number;
   activeDirectives: number;
-  recentEventCount24h: number;
-  recentEventCount7d: number;
+  eventCount: number;
+  successRate: number;
+  avgCredits: number;
+  avgDurationMs: number;
   latestEventAt: string | null;
   hottestAgents: AgentSummary[];
   recentFailures: SystemHistoryEvent[];
@@ -134,6 +140,19 @@ export interface ControlPlaneImportBundle {
   evaluations?: EvaluationRecord[];
   releases?: ReleaseDecision[];
 }
+
+export const ANALYTICS_WINDOW_OPTIONS: Array<{ id: AnalyticsWindow; label: string }> = [
+  { id: '24h', label: '24h' },
+  { id: '7d', label: '7d' },
+  { id: '30d', label: '30d' },
+  { id: 'all', label: 'All time' },
+];
+
+const ANALYTICS_WINDOW_MS: Record<Exclude<AnalyticsWindow, 'all'>, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+};
 
 const DEFAULT_POLICY: PolicySnapshot = {
   mode: 'recommended',
@@ -787,12 +806,108 @@ function computeAverage(values: number[]) {
   return values.reduce((total, value) => total + value, 0) / values.length;
 }
 
-function isWithinWindow(timestamp: string | null | undefined, windowMs: number) {
+function getTimestampMs(timestamp: string | null | undefined) {
+  if (!timestamp) {
+    return null;
+  }
+
+  const parsed = new Date(timestamp).getTime();
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isWithinWindow(timestamp: string | null | undefined, windowMs: number, referenceMs: number) {
   if (!timestamp) {
     return false;
   }
 
-  return Date.now() - new Date(timestamp).getTime() <= windowMs;
+  const eventMs = getTimestampMs(timestamp);
+  if (eventMs == null) {
+    return false;
+  }
+
+  return referenceMs - eventMs <= windowMs;
+}
+
+function getSystemReferenceMs(systemState: ControlPlaneSystemState | null | undefined) {
+  if (!systemState) {
+    return Date.now();
+  }
+
+  const timestamps = [
+    ...systemState.executions.flatMap((execution) => [execution.finishedAt ?? null, execution.startedAt]),
+    ...Object.values(systemState.executionSpans)
+      .flat()
+      .flatMap((span) => [span.finishedAt ?? null, span.startedAt]),
+    ...Object.values(systemState.executionMetrics)
+      .flat()
+      .map((sample) => sample.ts),
+    ...systemState.interventions.flatMap((intervention) => [intervention.appliedAt ?? null, intervention.requestedAt]),
+    ...systemState.evaluations.map((evaluation) => evaluation.createdAt),
+    ...systemState.releases.flatMap((release) => [release.appliedAt ?? null, release.requestedAt]),
+  ]
+    .map((timestamp) => getTimestampMs(timestamp))
+    .filter((timestamp): timestamp is number => timestamp != null);
+
+  return timestamps.length ? Math.max(...timestamps) : Date.now();
+}
+
+function getAnalyticsWindowMs(window: AnalyticsWindow) {
+  return window === 'all' ? null : ANALYTICS_WINDOW_MS[window];
+}
+
+export function getAnalyticsWindowLabel(window: AnalyticsWindow) {
+  return ANALYTICS_WINDOW_OPTIONS.find((option) => option.id === window)?.label ?? 'All time';
+}
+
+export function filterSystemStateByWindow(
+  systemState: ControlPlaneSystemState | null | undefined,
+  window: AnalyticsWindow,
+): ControlPlaneSystemState | null {
+  if (!systemState) {
+    return null;
+  }
+
+  const windowMs = getAnalyticsWindowMs(window);
+  if (windowMs == null) {
+    return systemState;
+  }
+
+  const referenceMs = getSystemReferenceMs(systemState);
+  const executionIds = new Set(
+    systemState.executions
+      .filter((execution) => isWithinWindow(execution.finishedAt ?? execution.startedAt, windowMs, referenceMs))
+      .map((execution) => execution.executionId),
+  );
+
+  return {
+    ...systemState,
+    executions: systemState.executions.filter((execution) => executionIds.has(execution.executionId)),
+    executionSpans: Object.fromEntries(
+      Object.entries(systemState.executionSpans)
+        .filter(([executionId]) => executionIds.has(executionId))
+        .map(([executionId, spans]) => [
+          executionId,
+          spans.filter((span) => isWithinWindow(span.finishedAt ?? span.startedAt, windowMs, referenceMs)),
+        ]),
+    ),
+    executionMetrics: Object.fromEntries(
+      Object.entries(systemState.executionMetrics)
+        .filter(([executionId]) => executionIds.has(executionId))
+        .map(([executionId, metrics]) => [
+          executionId,
+          metrics.filter((sample) => isWithinWindow(sample.ts, windowMs, referenceMs)),
+        ]),
+    ),
+    interventions: systemState.interventions.filter((intervention) =>
+      isWithinWindow(intervention.appliedAt ?? intervention.requestedAt, windowMs, referenceMs),
+    ),
+    evaluations: systemState.evaluations.filter((evaluation) =>
+      isWithinWindow(evaluation.createdAt, windowMs, referenceMs),
+    ),
+    releases: systemState.releases.filter((release) =>
+      isWithinWindow(release.appliedAt ?? release.requestedAt, windowMs, referenceMs),
+    ),
+  };
 }
 
 export function summarizeAgent(systemState: ControlPlaneSystemState | null | undefined, agentId: string): AgentSummary | null {
@@ -848,6 +963,20 @@ export function summarizeAgents(systemState: ControlPlaneSystemState | null | un
     .map((agent) => summarizeAgent(systemState, agent.agentId))
     .filter((summary): summary is AgentSummary => summary != null)
     .sort((left, right) => right.pressureScore - left.pressureScore || compareByNewest(left.lastActiveAt ?? undefined, right.lastActiveAt ?? undefined));
+}
+
+export function filterAgentSummaries(agentSummaries: AgentSummary[], focus: AgentRosterFocus): AgentSummary[] {
+  switch (focus) {
+    case 'attention':
+      return agentSummaries.filter((summary) => summary.failedSpanCount > 0 || summary.activeInterventionCount > 0);
+    case 'failures':
+      return agentSummaries.filter((summary) => summary.failedSpanCount > 0);
+    case 'directives':
+      return agentSummaries.filter((summary) => summary.activeInterventionCount > 0);
+    case 'all':
+    default:
+      return agentSummaries;
+  }
 }
 
 export function summarizeSystem(systemState: ControlPlaneSystemState | null | undefined): SystemSummary | null {
@@ -968,24 +1097,31 @@ export function summarizeFleetAnalytics(systemState: ControlPlaneSystemState | n
   const spans = Object.values(systemState.executionSpans).flat();
   const history = buildSystemHistoryEvents(systemState);
   const hottestAgents = summarizeAgents(systemState).slice(0, 3);
+  const executionMetrics = Object.values(systemState.executionMetrics).flat();
+  const durationSamples = executionMetrics.filter((sample) => sample.metric === 'duration.ms' && sample.scopeType === 'execution');
+  const creditSamples = executionMetrics.filter((sample) => sample.metric === 'credits.actual' && sample.scopeType === 'execution');
   const recentFailures = history.filter((event) =>
     ['failed', 'hold', 'rollback'].includes(event.status),
   );
+  const succeededExecutions = systemState.executions.filter((execution) => execution.status === 'succeeded').length;
 
   return {
+    executionCount: systemState.executions.length,
     executionStatusCounts: {
       running: systemState.executions.filter((execution) => execution.status === 'running').length,
-      succeeded: systemState.executions.filter((execution) => execution.status === 'succeeded').length,
+      succeeded: succeededExecutions,
       failed: systemState.executions.filter((execution) => execution.status === 'failed').length,
     },
     totalSpans: spans.length,
     failedSpans: spans.filter((span) => span.status === 'failed').length,
     activeDirectives: systemState.interventions.filter((intervention) => intervention.status === 'applied').length,
-    recentEventCount24h: history.filter((event) => isWithinWindow(event.occurredAt, 24 * 60 * 60 * 1000)).length,
-    recentEventCount7d: history.filter((event) => isWithinWindow(event.occurredAt, 7 * 24 * 60 * 60 * 1000)).length,
+    eventCount: history.length,
+    successRate: systemState.executions.length ? succeededExecutions / systemState.executions.length : 1,
     latestEventAt: history[0]?.occurredAt ?? null,
     hottestAgents,
     recentFailures: recentFailures.slice(0, 4),
+    avgCredits: computeAverage(creditSamples.map((sample) => sample.value)),
+    avgDurationMs: computeAverage(durationSamples.map((sample) => sample.value)),
   };
 }
 

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -34,6 +34,38 @@ export interface LoadControlPlaneStateOptions {
   fetch?: typeof globalThis.fetch;
 }
 
+export function getExecutionForRun(systemState: ControlPlaneSystemState | null | undefined, runId: string) {
+  if (!systemState) {
+    return null;
+  }
+
+  return systemState.executions.find((execution) => execution.runId === runId) ?? null;
+}
+
+export function getExecutionSpans(systemState: ControlPlaneSystemState | null | undefined, executionId?: string) {
+  if (!systemState || !executionId) {
+    return [];
+  }
+
+  return systemState.executionSpans[executionId] ?? [];
+}
+
+export function getExecutionMetrics(systemState: ControlPlaneSystemState | null | undefined, executionId?: string) {
+  if (!systemState || !executionId) {
+    return [];
+  }
+
+  return systemState.executionMetrics[executionId] ?? [];
+}
+
+export function getAgentLabel(systemState: ControlPlaneSystemState | null | undefined, agentId?: string) {
+  if (!systemState || !agentId) {
+    return null;
+  }
+
+  return systemState.agents.find((agent) => agent.agentId === agentId)?.label ?? null;
+}
+
 function buildApiUrl(apiBaseUrl: string, pathname: string) {
   if (!apiBaseUrl) {
     return pathname;

--- a/apps/web/src/app/control-plane.ts
+++ b/apps/web/src/app/control-plane.ts
@@ -1,0 +1,134 @@
+import type {
+  AgentDefinition,
+  EvaluationRecord,
+  ExecutionRecord,
+  InterventionRecord,
+  MetricSample,
+  ReleaseDecision,
+  RuntimeRegistration,
+  SpanRecord,
+  SystemDefinition,
+  TopologySnapshot,
+} from '@agent-studio/contracts';
+
+export interface ControlPlaneSystemState {
+  system: SystemDefinition;
+  agents: AgentDefinition[];
+  topology: TopologySnapshot | null;
+  executions: ExecutionRecord[];
+  executionSpans: Record<string, SpanRecord[]>;
+  executionMetrics: Record<string, MetricSample[]>;
+  interventions: InterventionRecord[];
+  evaluations: EvaluationRecord[];
+  releases: ReleaseDecision[];
+}
+
+export interface ControlPlaneState {
+  runtimes: RuntimeRegistration[];
+  systems: ControlPlaneSystemState[];
+  systemsByWorkflowId: Record<string, ControlPlaneSystemState>;
+}
+
+export interface LoadControlPlaneStateOptions {
+  apiBaseUrl?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+function buildApiUrl(apiBaseUrl: string, pathname: string) {
+  if (!apiBaseUrl) {
+    return pathname;
+  }
+
+  return new URL(pathname, `${apiBaseUrl.replace(/\/+$/, '')}/`).toString();
+}
+
+async function fetchJson<T>(fetcher: typeof globalThis.fetch, apiBaseUrl: string, pathname: string): Promise<T> {
+  const response = await fetcher(buildApiUrl(apiBaseUrl, pathname), {
+    headers: {
+      accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load ${pathname} (${response.status}).`);
+  }
+
+  return (await response.json()) as T;
+}
+
+function readWorkflowId(system: SystemDefinition) {
+  const metadata = system.metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  const workflowId = (metadata as Record<string, unknown>).workflowId;
+
+  return typeof workflowId === 'string' && workflowId.trim().length > 0 ? workflowId : undefined;
+}
+
+export async function loadControlPlaneState(options: LoadControlPlaneStateOptions = {}): Promise<ControlPlaneState> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  if (!fetcher) {
+    throw new Error('Fetch is not available in this environment.');
+  }
+
+  const apiBaseUrl = options.apiBaseUrl ?? import.meta.env.VITE_API_URL ?? '';
+  const runtimesPayload = await fetchJson<{ items: RuntimeRegistration[] }>(fetcher, apiBaseUrl, '/api/control/runtimes');
+  const systemsPayload = await fetchJson<{ items: SystemDefinition[] }>(fetcher, apiBaseUrl, '/api/control/systems');
+
+  const systems = await Promise.all(
+    systemsPayload.items.map(async (system) => {
+      const [agentsPayload, executionsPayload, interventionsPayload, evaluationsPayload, releasesPayload, topologyPayload] =
+        await Promise.all([
+          fetchJson<{ items: AgentDefinition[] }>(fetcher, apiBaseUrl, `/api/control/systems/${system.systemId}/agents`),
+          fetchJson<{ items: ExecutionRecord[] }>(fetcher, apiBaseUrl, `/api/control/systems/${system.systemId}/executions`),
+          fetchJson<{ items: InterventionRecord[] }>(fetcher, apiBaseUrl, `/api/control/systems/${system.systemId}/interventions`),
+          fetchJson<{ items: EvaluationRecord[] }>(fetcher, apiBaseUrl, `/api/control/systems/${system.systemId}/evaluations`),
+          fetchJson<{ items: ReleaseDecision[] }>(fetcher, apiBaseUrl, `/api/control/systems/${system.systemId}/releases`),
+          fetchJson<{ item: TopologySnapshot }>(fetcher, apiBaseUrl, `/api/control/systems/${system.systemId}/topology`).catch(() => ({ item: null })),
+        ]);
+
+      const executionDetails = await Promise.all(
+        executionsPayload.items.map(async (execution) => {
+          const [spansPayload, metricsPayload] = await Promise.all([
+            fetchJson<{ items: SpanRecord[] }>(fetcher, apiBaseUrl, `/api/control/executions/${execution.executionId}/spans`),
+            fetchJson<{ items: MetricSample[] }>(fetcher, apiBaseUrl, `/api/control/executions/${execution.executionId}/metrics`),
+          ]);
+
+          return {
+            executionId: execution.executionId,
+            spans: spansPayload.items,
+            metrics: metricsPayload.items,
+          };
+        }),
+      );
+
+      return {
+        system,
+        agents: agentsPayload.items,
+        topology: topologyPayload.item,
+        executions: executionsPayload.items,
+        executionSpans: Object.fromEntries(executionDetails.map((detail) => [detail.executionId, detail.spans])),
+        executionMetrics: Object.fromEntries(executionDetails.map((detail) => [detail.executionId, detail.metrics])),
+        interventions: interventionsPayload.items,
+        evaluations: evaluationsPayload.items,
+        releases: releasesPayload.items,
+      } satisfies ControlPlaneSystemState;
+    }),
+  );
+
+  const systemsByWorkflowId = Object.fromEntries(
+    systems.flatMap((systemState) => {
+      const workflowId = readWorkflowId(systemState.system);
+
+      return workflowId ? ([[workflowId, systemState]] as const) : [];
+    }),
+  );
+
+  return {
+    runtimes: runtimesPayload.items,
+    systems,
+    systemsByWorkflowId,
+  };
+}

--- a/apps/web/src/app/routes.test.ts
+++ b/apps/web/src/app/routes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAppRoute, parseAppRoute } from './routes';
+
+describe('app routes', () => {
+  it('parses the system overview route', () => {
+    expect(parseAppRoute('/systems/system_alpha')).toEqual({
+      view: 'overview',
+      systemId: 'system_alpha',
+    });
+  });
+
+  it('parses room routes for a system', () => {
+    expect(parseAppRoute('/systems/system_alpha/replay')).toEqual({
+      view: 'replay',
+      systemId: 'system_alpha',
+    });
+  });
+
+  it('parses the connect route', () => {
+    expect(parseAppRoute('/connect')).toEqual({
+      view: 'connect',
+      systemId: null,
+    });
+  });
+
+  it('builds stable deep-link routes', () => {
+    expect(
+      buildAppRoute({
+        view: 'optimize',
+        systemId: 'system alpha',
+      }),
+    ).toBe('/systems/system%20alpha/optimize');
+  });
+});

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -1,0 +1,64 @@
+export type ViewId = 'overview' | 'live' | 'replay' | 'optimize' | 'connect';
+
+export interface AppRouteState {
+  view: ViewId;
+  systemId: string | null;
+}
+
+function normalizePathname(pathname: string) {
+  const normalized = pathname.replace(/\/+$/, '');
+
+  return normalized.length > 0 ? normalized : '/';
+}
+
+export function parseAppRoute(pathname: string): AppRouteState {
+  const normalized = normalizePathname(pathname);
+  const parts = normalized.split('/').filter(Boolean);
+
+  if (parts[0] === 'connect') {
+    return {
+      view: 'connect',
+      systemId: null,
+    };
+  }
+
+  if (parts[0] === 'systems' && parts[1]) {
+    const systemId = decodeURIComponent(parts[1]);
+    const view = parts[2];
+
+    if (view === 'live' || view === 'replay' || view === 'optimize') {
+      return {
+        view,
+        systemId,
+      };
+    }
+
+    return {
+      view: 'overview',
+      systemId,
+    };
+  }
+
+  return {
+    view: 'overview',
+    systemId: null,
+  };
+}
+
+export function buildAppRoute(route: AppRouteState) {
+  if (route.view === 'connect') {
+    return '/connect';
+  }
+
+  if (!route.systemId) {
+    return '/';
+  }
+
+  const encodedSystemId = encodeURIComponent(route.systemId);
+
+  if (route.view === 'overview') {
+    return `/systems/${encodedSystemId}`;
+  }
+
+  return `/systems/${encodedSystemId}/${route.view}`;
+}

--- a/apps/web/src/features/connect/ConnectPanel.tsx
+++ b/apps/web/src/features/connect/ConnectPanel.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 
-import type { ControlPlaneImportBundle, ControlPlaneSystemState } from '../../app/control-plane';
+import type { ControlPlaneImportBundle, ControlPlaneStorageInfo, ControlPlaneSystemState } from '../../app/control-plane';
 import { ingestControlPlaneBundle, ingestControlPlaneItems } from '../../app/control-plane';
 
 interface ConnectPanelProps {
   selectedSystem: ControlPlaneSystemState | null;
+  storage: ControlPlaneStorageInfo | null;
   onRefresh: (nextSystemId?: string) => Promise<void> | void;
 }
 
@@ -39,7 +40,7 @@ function createId(prefix: string, seed: string) {
   return `${prefix}_${slug(seed)}_${Date.now().toString(36)}`;
 }
 
-export function ConnectPanel({ selectedSystem, onRefresh }: ConnectPanelProps) {
+export function ConnectPanel({ selectedSystem, storage, onRefresh }: ConnectPanelProps) {
   const [registrationForm, setRegistrationForm] = useState(INITIAL_REGISTRATION_FORM);
   const [bundleText, setBundleText] = useState<string>('{\n  "agents": [],\n  "topologies": [],\n  "executions": [],\n  "spans": [],\n  "metrics": []\n}');
   const [status, setStatus] = useState<string | null>(null);
@@ -122,6 +123,15 @@ export function ConnectPanel({ selectedSystem, onRefresh }: ConnectPanelProps) {
           </p>
         </div>
         <span className="meta-chip">{selectedSystem?.system.name ?? 'No system selected'}</span>
+      </div>
+      <div className={`inline-callout ${storage?.persistenceEnabled ? 'inline-callout--success' : 'inline-callout--warning'}`}>
+        <span className="eyebrow">Storage mode</span>
+        <p>
+          <strong>{storage?.mode === 'file' ? 'Persistent file store' : 'Ephemeral memory store'}</strong>
+          {' '}
+          {storage?.detail ?? 'Storage metadata unavailable.'}
+        </p>
+        {storage?.filePath ? <code>{storage.filePath}</code> : null}
       </div>
       <div className="connect-grid">
         <section className="mini-surface">

--- a/apps/web/src/features/connect/ConnectPanel.tsx
+++ b/apps/web/src/features/connect/ConnectPanel.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+
+import type { ControlPlaneImportBundle, ControlPlaneSystemState } from '../../app/control-plane';
+import { ingestControlPlaneBundle, ingestControlPlaneItems } from '../../app/control-plane';
+
+interface ConnectPanelProps {
+  selectedSystem: ControlPlaneSystemState | null;
+  onRefresh: (nextSystemId?: string) => Promise<void> | void;
+}
+
+interface RegistrationFormState {
+  runtimeLabel: string;
+  runtimeKind: string;
+  adapterId: string;
+  systemName: string;
+  systemDescription: string;
+  workspaceId: string;
+}
+
+const INITIAL_REGISTRATION_FORM: RegistrationFormState = {
+  runtimeLabel: 'Imported runtime',
+  runtimeKind: 'custom',
+  adapterId: 'custom-ingest',
+  systemName: 'Imported system',
+  systemDescription: 'A system imported through the Agent Studio control-plane ingest surface.',
+  workspaceId: 'workspace_imported',
+};
+
+function slug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+function createId(prefix: string, seed: string) {
+  return `${prefix}_${slug(seed)}_${Date.now().toString(36)}`;
+}
+
+export function ConnectPanel({ selectedSystem, onRefresh }: ConnectPanelProps) {
+  const [registrationForm, setRegistrationForm] = useState(INITIAL_REGISTRATION_FORM);
+  const [bundleText, setBundleText] = useState<string>('{\n  "agents": [],\n  "topologies": [],\n  "executions": [],\n  "spans": [],\n  "metrics": []\n}');
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleRegisterRuntimeAndSystem() {
+    setSubmitting(true);
+    setStatus(null);
+    setError(null);
+
+    try {
+      const runtimeId = createId('runtime', registrationForm.runtimeLabel);
+      const systemId = createId('system', registrationForm.systemName);
+
+      await ingestControlPlaneItems('/api/control/ingest/runtimes', {
+        runtimeId,
+        kind: registrationForm.runtimeKind,
+        adapterId: registrationForm.adapterId,
+        label: registrationForm.runtimeLabel,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      await ingestControlPlaneItems('/api/control/ingest/systems', {
+        systemId,
+        workspaceId: registrationForm.workspaceId,
+        name: registrationForm.systemName,
+        description: registrationForm.systemDescription,
+        runtimeIds: [runtimeId],
+        primaryRuntimeId: runtimeId,
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      await onRefresh(systemId);
+      setStatus(`Registered ${registrationForm.systemName} on ${registrationForm.runtimeLabel}.`);
+    } catch (submissionError) {
+      setError(submissionError instanceof Error ? submissionError.message : 'Failed to register runtime and system.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleImportBundle() {
+    setSubmitting(true);
+    setStatus(null);
+    setError(null);
+
+    try {
+      const parsed = JSON.parse(bundleText) as ControlPlaneImportBundle;
+      await ingestControlPlaneBundle(parsed);
+      const nextSystemId = parsed.systems?.[0]?.systemId;
+      await onRefresh(nextSystemId);
+      setStatus('Imported the control-plane bundle successfully.');
+    } catch (submissionError) {
+      setError(submissionError instanceof Error ? submissionError.message : 'Failed to import the control-plane bundle.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function updateRegistrationField<Key extends keyof RegistrationFormState>(key: Key, value: RegistrationFormState[Key]) {
+    setRegistrationForm((current) => ({
+      ...current,
+      [key]: value,
+    }));
+  }
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Connect and import</p>
+          <h2>Bring your own system</h2>
+          <p className="muted">
+            Register a runtime and system, then ingest agents, topology, executions, spans, metrics, interventions,
+            evaluations, and releases through the same routes the seeded demo uses.
+          </p>
+        </div>
+        <span className="meta-chip">{selectedSystem?.system.name ?? 'No system selected'}</span>
+      </div>
+      <div className="connect-grid">
+        <section className="mini-surface">
+          <p className="eyebrow">Quick register</p>
+          <div className="text-field">
+            <span>Runtime label</span>
+            <input value={registrationForm.runtimeLabel} onChange={(event) => updateRegistrationField('runtimeLabel', event.target.value)} />
+          </div>
+          <div className="connect-split">
+            <label className="text-field">
+              <span>Runtime kind</span>
+              <input value={registrationForm.runtimeKind} onChange={(event) => updateRegistrationField('runtimeKind', event.target.value)} />
+            </label>
+            <label className="text-field">
+              <span>Adapter ID</span>
+              <input value={registrationForm.adapterId} onChange={(event) => updateRegistrationField('adapterId', event.target.value)} />
+            </label>
+          </div>
+          <div className="text-field">
+            <span>System name</span>
+            <input value={registrationForm.systemName} onChange={(event) => updateRegistrationField('systemName', event.target.value)} />
+          </div>
+          <div className="text-field">
+            <span>System description</span>
+            <textarea rows={4} value={registrationForm.systemDescription} onChange={(event) => updateRegistrationField('systemDescription', event.target.value)} />
+          </div>
+          <div className="text-field">
+            <span>Workspace ID</span>
+            <input value={registrationForm.workspaceId} onChange={(event) => updateRegistrationField('workspaceId', event.target.value)} />
+          </div>
+          <button type="button" className="control-strip__primary" onClick={handleRegisterRuntimeAndSystem} disabled={submitting}>
+            {submitting ? 'Submitting…' : 'Register runtime and system'}
+          </button>
+        </section>
+        <section className="mini-surface">
+          <p className="eyebrow">Bulk import</p>
+          <p className="muted">
+            Paste a control-plane bundle with any of these keys: `runtimes`, `systems`, `agents`, `topologies`,
+            `executions`, `spans`, `metrics`, `interventions`, `evaluations`, `releases`.
+          </p>
+          <label className="text-field">
+            <span>Import JSON</span>
+            <textarea rows={16} value={bundleText} onChange={(event) => setBundleText(event.target.value)} />
+          </label>
+          <button type="button" className="control-strip__primary" onClick={handleImportBundle} disabled={submitting}>
+            {submitting ? 'Importing…' : 'Import control-plane bundle'}
+          </button>
+        </section>
+      </div>
+      {status ? (
+        <div className="inline-callout inline-callout--success">
+          <span className="eyebrow">Status</span>
+          <p>{status}</p>
+        </div>
+      ) : null}
+      {error ? (
+        <div className="inline-callout inline-callout--warning">
+          <span className="eyebrow">Import error</span>
+          <p>{error}</p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/connect/ConnectPanel.tsx
+++ b/apps/web/src/features/connect/ConnectPanel.tsx
@@ -127,11 +127,18 @@ export function ConnectPanel({ selectedSystem, storage, onRefresh }: ConnectPane
       <div className={`inline-callout ${storage?.persistenceEnabled ? 'inline-callout--success' : 'inline-callout--warning'}`}>
         <span className="eyebrow">Storage mode</span>
         <p>
-          <strong>{storage?.mode === 'file' ? 'Persistent file store' : 'Ephemeral memory store'}</strong>
+          <strong>
+            {storage?.mode === 'blob'
+              ? 'Persistent hosted blob store'
+              : storage?.mode === 'file'
+                ? 'Persistent file store'
+                : 'Ephemeral memory store'}
+          </strong>
           {' '}
           {storage?.detail ?? 'Storage metadata unavailable.'}
         </p>
         {storage?.filePath ? <code>{storage.filePath}</code> : null}
+        {!storage?.filePath && storage?.blobPath ? <code>{storage.blobPath}</code> : null}
       </div>
       <div className="connect-grid">
         <section className="mini-surface">

--- a/apps/web/src/features/live/LiveAgentTopologySection.tsx
+++ b/apps/web/src/features/live/LiveAgentTopologySection.tsx
@@ -36,7 +36,10 @@ type DragState = {
   pointerId: number;
 };
 
+type LayoutMode = 'orbit' | 'free';
+
 const POSITION_STORAGE_PREFIX = 'agent-studio-topology-layout:';
+const MODE_STORAGE_PREFIX = 'agent-studio-topology-mode:';
 
 const POSITION_PRESETS: Record<number, Array<[number, number]>> = {
   1: [[50, 18]],
@@ -195,6 +198,31 @@ function storePositions(workflowId: string, positions: Record<string, NodePositi
   }
 }
 
+function getStoredLayoutMode(workflowId: string): LayoutMode | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(`${MODE_STORAGE_PREFIX}${workflowId}`);
+    return raw === 'free' || raw === 'orbit' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeLayoutMode(workflowId: string, mode: LayoutMode) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(`${MODE_STORAGE_PREFIX}${workflowId}`, mode);
+  } catch {
+    // Ignore storage failures in demo mode.
+  }
+}
+
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
@@ -215,13 +243,18 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
   const dragStateRef = useRef<DragState | null>(null);
   const [draggingRole, setDraggingRole] = useState<string | null>(null);
   const [nodePositions, setNodePositions] = useState<Record<string, NodePosition>>({});
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>('orbit');
+
+  useEffect(() => {
+    setLayoutMode(getStoredLayoutMode(workflow.workflowId) ?? 'orbit');
+  }, [workflow.workflowId]);
 
   useEffect(() => {
     const stored = getStoredPositions(workflow.workflowId);
     const nextPositions = Object.fromEntries(
       roleNodes.map((node) => [
         node.role,
-        stored?.[node.role]
+        layoutMode === 'free' && stored?.[node.role]
           ? {
               x: clamp(stored[node.role].x, 10, 90),
               y: clamp(stored[node.role].y, 12, 88),
@@ -234,18 +267,24 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
     );
 
     setNodePositions(nextPositions);
-  }, [workflow.workflowId, roleSignature]);
+  }, [workflow.workflowId, roleSignature, layoutMode]);
 
   useEffect(() => {
     if (!Object.keys(nodePositions).length) {
       return;
     }
 
-    storePositions(workflow.workflowId, nodePositions);
-  }, [nodePositions, workflow.workflowId]);
+    if (layoutMode === 'free') {
+      storePositions(workflow.workflowId, nodePositions);
+    }
+  }, [layoutMode, nodePositions, workflow.workflowId]);
 
   useEffect(() => {
-    if (!draggingRole) {
+    storeLayoutMode(workflow.workflowId, layoutMode);
+  }, [layoutMode, workflow.workflowId]);
+
+  useEffect(() => {
+    if (!draggingRole || layoutMode !== 'free') {
       return;
     }
 
@@ -300,7 +339,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
     };
   }, [draggingRole]);
 
-  function resetLayout() {
+  function snapToOrbit() {
     const nextPositions = Object.fromEntries(
       roleNodes.map((node) => [
         node.role,
@@ -311,7 +350,16 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
       ]),
     );
 
+    dragStateRef.current = null;
+    setDraggingRole(null);
     setNodePositions(nextPositions);
+    setLayoutMode('orbit');
+  }
+
+  function switchToFreeArrange() {
+    dragStateRef.current = null;
+    setDraggingRole(null);
+    setLayoutMode('free');
   }
 
   return (
@@ -322,9 +370,29 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
           <h3>Working agents and command flow</h3>
         </div>
         <div className="live-topology__toolbar">
-          <button type="button" className="ghost-button" onClick={resetLayout}>
-            Snap to orbit
-          </button>
+          <div className="live-topology__mode-toggle" role="tablist" aria-label="Topology layout mode">
+            <button
+              type="button"
+              className={`live-topology__mode-button ${layoutMode === 'orbit' ? 'live-topology__mode-button--active' : ''}`}
+              aria-pressed={layoutMode === 'orbit'}
+              onClick={snapToOrbit}
+            >
+              Orbit
+            </button>
+            <button
+              type="button"
+              className={`live-topology__mode-button ${layoutMode === 'free' ? 'live-topology__mode-button--active' : ''}`}
+              aria-pressed={layoutMode === 'free'}
+              onClick={switchToFreeArrange}
+            >
+              Free arrange
+            </button>
+          </div>
+          {layoutMode === 'free' ? (
+            <button type="button" className="ghost-button" onClick={snapToOrbit}>
+              Snap to orbit
+            </button>
+          ) : null}
           <span className={`status-pill status-pill--${failedCount > 0 ? 'failed' : run.status}`}>
             {failedCount > 0 ? 'Pressure visible' : titleCaseStatus(run.status)}
           </span>
@@ -338,23 +406,33 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
         {draggingRole
           ? `Arranging ${roleNodes.find((node) => node.role === draggingRole)?.label ?? 'agent'}`
           : bottleneckLabel
-            ? `Current pressure point: ${bottleneckLabel}. Drag any agent card to rearrange the layout, or snap back to orbit at any time.`
-            : 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this workflow.'}
+            ? layoutMode === 'free'
+              ? `Current pressure point: ${bottleneckLabel}. Drag any agent card to rearrange the layout, or snap back to orbit at any time.`
+              : `Current pressure point: ${bottleneckLabel}. Switch to Free arrange if you want to move the agents manually.`
+            : layoutMode === 'free'
+              ? 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this workflow.'
+              : 'Orbit mode keeps the topology in its canonical layout. Switch to Free arrange to move the agents manually.'}
       </p>
 
       <div className="live-topology">
-        <div ref={canvasRef} className="live-topology__canvas">
+        <div
+          ref={canvasRef}
+          className={`live-topology__canvas ${layoutMode === 'free' ? 'live-topology__canvas--free' : 'live-topology__canvas--orbit'} ${draggingRole ? 'live-topology__canvas--dragging' : ''}`}
+        >
           <div className="live-topology__orbit live-topology__orbit--outer" />
           <div className="live-topology__orbit live-topology__orbit--inner" />
           <div className="live-topology__glow" />
           <svg className="live-topology__links" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-            {roleNodes.map((node) => {
+            {roleNodes.map((node, index) => {
               const position = nodePositions[node.role] ?? { x: node.x, y: node.y };
               const isBottleneck = node.role === bottleneckRole;
+              const isDragged = draggingRole === node.role;
               const path = buildLinkPath(position.x, position.y);
               const toneClass =
                 node.status === 'failed'
                   ? 'live-topology__link--failed'
+                  : isDragged
+                    ? 'live-topology__link--dragging'
                   : isBottleneck
                     ? 'live-topology__link--bottleneck'
                     : node.status === 'active'
@@ -365,6 +443,33 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
                 <g key={`link-${node.role}`}>
                   <path className={`live-topology__link live-topology__link-glow ${toneClass}`} d={path} />
                   <path className={`live-topology__link live-topology__link-line ${toneClass}`} d={path} />
+                  {node.status !== 'standby' || isBottleneck ? (
+                    <>
+                      <circle
+                        className={`live-topology__packet ${isBottleneck ? 'live-topology__packet--bottleneck' : node.status === 'failed' ? 'live-topology__packet--failed' : 'live-topology__packet--active'} ${isDragged ? 'live-topology__packet--dragging' : ''}`}
+                        r={isBottleneck ? 0.95 : 0.72}
+                      >
+                        <animateMotion
+                          path={path}
+                          dur={isDragged ? '1.6s' : isBottleneck ? '2.1s' : '3.2s'}
+                          begin={`${index * 0.35}s`}
+                          repeatCount="indefinite"
+                          rotate="auto"
+                        />
+                      </circle>
+                      {isBottleneck ? (
+                        <circle className="live-topology__packet live-topology__packet--bottleneck" r={0.62}>
+                          <animateMotion
+                            path={path}
+                            dur="2.65s"
+                            begin={`${index * 0.35 + 0.9}s`}
+                            repeatCount="indefinite"
+                            rotate="auto"
+                          />
+                        </circle>
+                      ) : null}
+                    </>
+                  ) : null}
                 </g>
               );
             })}
@@ -396,6 +501,10 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
                   ['--float-duration' as string]: `${6.2 + (index % 3) * 0.8}s`,
                 }}
                 onPointerDown={(event) => {
+                  if (layoutMode !== 'free') {
+                    return;
+                  }
+
                   dragStateRef.current = {
                     role: node.role,
                     pointerId: event.pointerId,

--- a/apps/web/src/features/live/LiveAgentTopologySection.tsx
+++ b/apps/web/src/features/live/LiveAgentTopologySection.tsx
@@ -140,6 +140,32 @@ function formatDirectiveMode(mode?: DirectiveMode) {
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }
 
+function getBottleneckRole(replay: Replay, roleNodes: RoleNode[]) {
+  const failedStep = replay.stepExecutions.find((step) => step.status === 'failed');
+  if (failedStep?.assignedRole) {
+    return failedStep.assignedRole;
+  }
+
+  const recommendationPhase = replay.operationalContext?.recommendationEvidence[0]?.phase;
+  if (!recommendationPhase) {
+    return null;
+  }
+
+  const matchingExecution = replay.stepExecutions.find((step) => step.kind === recommendationPhase);
+  if (matchingExecution?.assignedRole) {
+    return matchingExecution.assignedRole;
+  }
+
+  return roleNodes.find((node) => node.phases.includes(recommendationPhase))?.role ?? null;
+}
+
+function buildLinkPath(x: number, y: number) {
+  const controlX = x < 50 ? 36 : 64;
+  const controlY = y < 50 ? 34 : 66;
+
+  return `M 50 50 C ${controlX} ${controlY}, ${x} ${y}, ${x} ${y}`;
+}
+
 function getStoredPositions(workflowId: string): Record<string, NodePosition> | null {
   if (typeof window === 'undefined') {
     return null;
@@ -183,6 +209,8 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
   const healthyAnchor = replay.operationalContext?.lastHealthyComparison;
   const recommendation = replay.operationalContext?.recommendationEvidence[0];
   const directiveCount = Object.keys(replay.studioState?.roleDirectives ?? {}).length;
+  const bottleneckRole = getBottleneckRole(replay, roleNodes);
+  const bottleneckLabel = roleNodes.find((node) => node.role === bottleneckRole)?.label ?? null;
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const dragStateRef = useRef<DragState | null>(null);
   const [draggingRole, setDraggingRole] = useState<string | null>(null);
@@ -295,7 +323,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
         </div>
         <div className="live-topology__toolbar">
           <button type="button" className="ghost-button" onClick={resetLayout}>
-            Reset layout
+            Snap to orbit
           </button>
           <span className={`status-pill status-pill--${failedCount > 0 ? 'failed' : run.status}`}>
             {failedCount > 0 ? 'Pressure visible' : titleCaseStatus(run.status)}
@@ -309,7 +337,9 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
       <p className="live-topology__hint">
         {draggingRole
           ? `Arranging ${roleNodes.find((node) => node.role === draggingRole)?.label ?? 'agent'}`
-          : 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this workflow.'}
+          : bottleneckLabel
+            ? `Current pressure point: ${bottleneckLabel}. Drag any agent card to rearrange the layout, or snap back to orbit at any time.`
+            : 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this workflow.'}
       </p>
 
       <div className="live-topology">
@@ -317,6 +347,28 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
           <div className="live-topology__orbit live-topology__orbit--outer" />
           <div className="live-topology__orbit live-topology__orbit--inner" />
           <div className="live-topology__glow" />
+          <svg className="live-topology__links" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+            {roleNodes.map((node) => {
+              const position = nodePositions[node.role] ?? { x: node.x, y: node.y };
+              const isBottleneck = node.role === bottleneckRole;
+              const path = buildLinkPath(position.x, position.y);
+              const toneClass =
+                node.status === 'failed'
+                  ? 'live-topology__link--failed'
+                  : isBottleneck
+                    ? 'live-topology__link--bottleneck'
+                    : node.status === 'active'
+                      ? 'live-topology__link--active'
+                      : 'live-topology__link--standby';
+
+              return (
+                <g key={`link-${node.role}`}>
+                  <path className={`live-topology__link live-topology__link-glow ${toneClass}`} d={path} />
+                  <path className={`live-topology__link live-topology__link-line ${toneClass}`} d={path} />
+                </g>
+              );
+            })}
+          </svg>
           <div className="live-topology__core">
             <p className="eyebrow">Control core</p>
             <strong>{workflow.name}</strong>
@@ -331,11 +383,12 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
           {roleNodes.map((node, index) => {
             const position = nodePositions[node.role] ?? { x: node.x, y: node.y };
             const isDragging = draggingRole === node.role;
+            const isBottleneck = node.role === bottleneckRole;
 
             return (
               <article
                 key={node.role}
-                className={`live-node live-node--${node.status} ${isDragging ? 'live-node--dragging' : ''}`}
+                className={`live-node live-node--${node.status} ${isBottleneck ? 'live-node--bottleneck' : ''} ${isDragging ? 'live-node--dragging' : ''}`}
                 style={{
                   left: `${position.x}%`,
                   top: `${position.y}%`,
@@ -357,6 +410,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
                   </div>
                   <span className={`live-node__status live-node__status--${node.status}`} />
                 </div>
+                {isBottleneck ? <p className="live-node__pressure">Pressure point</p> : null}
                 <p className="live-node__summary">{node.summary}</p>
                 <div className="live-node__tags">
                   <span className="meta-chip">{formatDirectiveMode(node.directiveMode)}</span>

--- a/apps/web/src/features/live/LiveAgentTopologySection.tsx
+++ b/apps/web/src/features/live/LiveAgentTopologySection.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 import type { DirectiveMode, Replay, Run, Workflow, WorkflowStep } from '@agent-studio/contracts';
 
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
@@ -20,9 +22,21 @@ type RoleNode = {
   durationMs?: number;
   credits?: number;
   stepCount: number;
-  left: string;
-  top: string;
+  x: number;
+  y: number;
 };
+
+type NodePosition = {
+  x: number;
+  y: number;
+};
+
+type DragState = {
+  role: string;
+  pointerId: number;
+};
+
+const POSITION_STORAGE_PREFIX = 'agent-studio-topology-layout:';
 
 const POSITION_PRESETS: Record<number, Array<[number, number]>> = {
   1: [[50, 18]],
@@ -108,8 +122,8 @@ function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
       durationMs: totalDuration || undefined,
       credits: totalCredits || undefined,
       stepCount: steps.length,
-      left: `${preset?.[0] ?? fallbackLeft}%`,
-      top: `${preset?.[1] ?? fallbackTop}%`,
+      x: preset?.[0] ?? fallbackLeft,
+      y: preset?.[1] ?? fallbackTop,
     };
   });
 }
@@ -126,8 +140,42 @@ function formatDirectiveMode(mode?: DirectiveMode) {
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }
 
+function getStoredPositions(workflowId: string): Record<string, NodePosition> | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(`${POSITION_STORAGE_PREFIX}${workflowId}`);
+    if (!raw) {
+      return null;
+    }
+
+    return JSON.parse(raw) as Record<string, NodePosition>;
+  } catch {
+    return null;
+  }
+}
+
+function storePositions(workflowId: string, positions: Record<string, NodePosition>) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(`${POSITION_STORAGE_PREFIX}${workflowId}`, JSON.stringify(positions));
+  } catch {
+    // Ignore storage failures in demo mode.
+  }
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
 export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTopologySectionProps) {
   const roleNodes = buildRoleNodes(workflow, replay);
+  const roleSignature = roleNodes.map((node) => node.role).join('|');
   const activeCount = roleNodes.filter((node) => node.status === 'active').length;
   const failedCount = roleNodes.filter((node) => node.status === 'failed').length;
   const phaseCount = new Set(workflow.steps.map((step) => step.kind)).size;
@@ -135,6 +183,108 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
   const healthyAnchor = replay.operationalContext?.lastHealthyComparison;
   const recommendation = replay.operationalContext?.recommendationEvidence[0];
   const directiveCount = Object.keys(replay.studioState?.roleDirectives ?? {}).length;
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const [draggingRole, setDraggingRole] = useState<string | null>(null);
+  const [nodePositions, setNodePositions] = useState<Record<string, NodePosition>>({});
+
+  useEffect(() => {
+    const stored = getStoredPositions(workflow.workflowId);
+    const nextPositions = Object.fromEntries(
+      roleNodes.map((node) => [
+        node.role,
+        stored?.[node.role]
+          ? {
+              x: clamp(stored[node.role].x, 10, 90),
+              y: clamp(stored[node.role].y, 12, 88),
+            }
+          : {
+              x: node.x,
+              y: node.y,
+            },
+      ]),
+    );
+
+    setNodePositions(nextPositions);
+  }, [workflow.workflowId, roleSignature]);
+
+  useEffect(() => {
+    if (!Object.keys(nodePositions).length) {
+      return;
+    }
+
+    storePositions(workflow.workflowId, nodePositions);
+  }, [nodePositions, workflow.workflowId]);
+
+  useEffect(() => {
+    if (!draggingRole) {
+      return;
+    }
+
+    function updateFromPointer(pointerId: number, clientX: number, clientY: number) {
+      if (!canvasRef.current || dragStateRef.current?.pointerId !== pointerId) {
+        return;
+      }
+
+      const rect = canvasRef.current.getBoundingClientRect();
+      const paddingX = Math.max(8, Math.min(14, (96 / rect.width) * 100));
+      const paddingY = Math.max(10, Math.min(16, (96 / rect.height) * 100));
+
+      const x = clamp(((clientX - rect.left) / rect.width) * 100, paddingX, 100 - paddingX);
+      const y = clamp(((clientY - rect.top) / rect.height) * 100, paddingY, 100 - paddingY);
+
+      setNodePositions((current) => ({
+        ...current,
+        [dragStateRef.current!.role]: {
+          x,
+          y,
+        },
+      }));
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+      if (!dragStateRef.current || event.pointerId !== dragStateRef.current.pointerId) {
+        return;
+      }
+
+      event.preventDefault();
+      updateFromPointer(event.pointerId, event.clientX, event.clientY);
+    }
+
+    function handlePointerEnd(event: PointerEvent) {
+      if (!dragStateRef.current || event.pointerId !== dragStateRef.current.pointerId) {
+        return;
+      }
+
+      updateFromPointer(event.pointerId, event.clientX, event.clientY);
+      dragStateRef.current = null;
+      setDraggingRole(null);
+    }
+
+    window.addEventListener('pointermove', handlePointerMove, { passive: false });
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+    };
+  }, [draggingRole]);
+
+  function resetLayout() {
+    const nextPositions = Object.fromEntries(
+      roleNodes.map((node) => [
+        node.role,
+        {
+          x: node.x,
+          y: node.y,
+        },
+      ]),
+    );
+
+    setNodePositions(nextPositions);
+  }
 
   return (
     <section className="surface surface--topology">
@@ -143,17 +293,27 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
           <p className="eyebrow">Live agent topology</p>
           <h3>Working agents and command flow</h3>
         </div>
-        <span className={`status-pill status-pill--${failedCount > 0 ? 'failed' : run.status}`}>
-          {failedCount > 0 ? 'Pressure visible' : titleCaseStatus(run.status)}
-        </span>
+        <div className="live-topology__toolbar">
+          <button type="button" className="ghost-button" onClick={resetLayout}>
+            Reset layout
+          </button>
+          <span className={`status-pill status-pill--${failedCount > 0 ? 'failed' : run.status}`}>
+            {failedCount > 0 ? 'Pressure visible' : titleCaseStatus(run.status)}
+          </span>
+        </div>
       </div>
       <p className="feature-summary">
         This is the piece the standalone demo was missing: the live command core in the middle, the active specialist
         lanes around it, and the strongest system signals next to the map.
       </p>
+      <p className="live-topology__hint">
+        {draggingRole
+          ? `Arranging ${roleNodes.find((node) => node.role === draggingRole)?.label ?? 'agent'}`
+          : 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this workflow.'}
+      </p>
 
       <div className="live-topology">
-        <div className="live-topology__canvas">
+        <div ref={canvasRef} className="live-topology__canvas">
           <div className="live-topology__orbit live-topology__orbit--outer" />
           <div className="live-topology__orbit live-topology__orbit--inner" />
           <div className="live-topology__glow" />
@@ -168,34 +328,51 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
             </div>
           </div>
 
-          {roleNodes.map((node) => (
-            <article
-              key={node.role}
-              className={`live-node live-node--${node.status}`}
-              style={{ left: node.left, top: node.top }}
-            >
-              <div className="live-node__header">
-                <div>
-                  <p className="live-node__label">{node.label}</p>
-                  <p className="live-node__meta">{node.stepCount} mapped steps</p>
+          {roleNodes.map((node, index) => {
+            const position = nodePositions[node.role] ?? { x: node.x, y: node.y };
+            const isDragging = draggingRole === node.role;
+
+            return (
+              <article
+                key={node.role}
+                className={`live-node live-node--${node.status} ${isDragging ? 'live-node--dragging' : ''}`}
+                style={{
+                  left: `${position.x}%`,
+                  top: `${position.y}%`,
+                  ['--float-delay' as string]: `${index * 0.45}s`,
+                  ['--float-duration' as string]: `${6.2 + (index % 3) * 0.8}s`,
+                }}
+                onPointerDown={(event) => {
+                  dragStateRef.current = {
+                    role: node.role,
+                    pointerId: event.pointerId,
+                  };
+                  setDraggingRole(node.role);
+                }}
+              >
+                <div className="live-node__header">
+                  <div>
+                    <p className="live-node__label">{node.label}</p>
+                    <p className="live-node__meta">{node.stepCount} mapped steps</p>
+                  </div>
+                  <span className={`live-node__status live-node__status--${node.status}`} />
                 </div>
-                <span className={`live-node__status live-node__status--${node.status}`} />
-              </div>
-              <p className="live-node__summary">{node.summary}</p>
-              <div className="live-node__tags">
-                <span className="meta-chip">{formatDirectiveMode(node.directiveMode)}</span>
-                {node.phases.slice(0, 2).map((phase) => (
-                  <span key={`${node.role}-${phase}`} className="meta-chip">
-                    {phase}
-                  </span>
-                ))}
-              </div>
-              <div className="live-node__metrics">
-                <span>{formatCredits(node.credits)}</span>
-                <span>{formatDuration(node.durationMs)}</span>
-              </div>
-            </article>
-          ))}
+                <p className="live-node__summary">{node.summary}</p>
+                <div className="live-node__tags">
+                  <span className="meta-chip">{formatDirectiveMode(node.directiveMode)}</span>
+                  {node.phases.slice(0, 2).map((phase) => (
+                    <span key={`${node.role}-${phase}`} className="meta-chip">
+                      {phase}
+                    </span>
+                  ))}
+                </div>
+                <div className="live-node__metrics">
+                  <span>{formatCredits(node.credits)}</span>
+                  <span>{formatDuration(node.durationMs)}</span>
+                </div>
+              </article>
+            );
+          })}
         </div>
 
         <div className="live-topology__rail">

--- a/apps/web/src/features/live/LiveAgentTopologySection.tsx
+++ b/apps/web/src/features/live/LiveAgentTopologySection.tsx
@@ -1,21 +1,30 @@
 import { useEffect, useRef, useState } from 'react';
 
-import type { DirectiveMode, Replay, Run, Workflow, WorkflowStep } from '@agent-studio/contracts';
+import type {
+  DirectiveMode,
+  Replay,
+  Run,
+  TopologyEdge,
+  Workflow,
+  WorkflowStep,
+} from '@agent-studio/contracts';
 
+import type { ControlPlaneSystemState } from '../../app/control-plane';
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface LiveAgentTopologySectionProps {
   workflow: Workflow;
   run: Run;
   replay: Replay;
+  controlPlane?: ControlPlaneSystemState | null;
 }
 
-type RoleNodeStatus = 'active' | 'failed' | 'standby';
+type NodeStatus = 'active' | 'failed' | 'standby';
 
-type RoleNode = {
-  role: string;
+type DisplayNode = {
+  id: string;
   label: string;
-  status: RoleNodeStatus;
+  status: NodeStatus;
   directiveMode?: DirectiveMode;
   phases: string[];
   summary: string;
@@ -26,13 +35,19 @@ type RoleNode = {
   y: number;
 };
 
+type DisplayEdge = {
+  id: string;
+  sourceId: string;
+  targetId: string;
+};
+
 type NodePosition = {
   x: number;
   y: number;
 };
 
 type DragState = {
-  role: string;
+  nodeId: string;
   pointerId: number;
 };
 
@@ -76,7 +91,50 @@ function formatRoleLabel(role: string) {
     .join(' ');
 }
 
-function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
+function formatDirectiveMode(mode?: DirectiveMode) {
+  if (!mode) {
+    return 'Steady';
+  }
+
+  if (mode === 'promote') {
+    return 'Promoted';
+  }
+
+  return mode.charAt(0).toUpperCase() + mode.slice(1);
+}
+
+function parseDirectiveMode(action?: string): DirectiveMode | undefined {
+  if (!action?.startsWith('directive.')) {
+    return undefined;
+  }
+
+  const mode = action.slice('directive.'.length);
+  if (mode === 'cheaper' || mode === 'review' || mode === 'promote') {
+    return mode;
+  }
+
+  return undefined;
+}
+
+function getPresetPosition(count: number, index: number) {
+  const preset = POSITION_PRESETS[count]?.[index];
+  if (preset) {
+    return {
+      x: preset[0],
+      y: preset[1],
+    };
+  }
+
+  const angle = (-Math.PI / 2) + ((Math.PI * 2) / Math.max(count, 1)) * index;
+  const radius = count <= 4 ? 31 : 39;
+
+  return {
+    x: 50 + Math.cos(angle) * radius,
+    y: 50 + Math.sin(angle) * radius,
+  };
+}
+
+function buildLegacyNodes(workflow: Workflow, replay: Replay): DisplayNode[] {
   const workflowStepsByRole = new Map<string, WorkflowStep[]>();
 
   for (const step of workflow.steps) {
@@ -91,27 +149,20 @@ function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
     const executedSteps = replay.stepExecutions.filter((step) => step.assignedRole === role);
     const directiveMode =
       replay.studioState?.roleDirectives?.[role]?.mode ?? executedSteps.find((step) => step.directiveMode)?.directiveMode;
-
     const failedStep = executedSteps.find((step) => step.status === 'failed');
     const activeStep = executedSteps.find((step) => step.status === 'running') ?? executedSteps[executedSteps.length - 1];
-
-    const status: RoleNodeStatus = failedStep
+    const status: NodeStatus = failedStep
       ? 'failed'
       : executedSteps.some((step) => step.status === 'running' || step.status === 'succeeded')
         ? 'active'
         : 'standby';
-
     const totalCredits = executedSteps.reduce((sum, step) => sum + (step.actualCredits ?? 0), 0);
     const totalDuration = executedSteps.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
     const phases = Array.from(new Set(steps.map((step) => step.kind)));
-    const preset = POSITION_PRESETS[roles.length]?.[index];
-    const angle = (-Math.PI / 2) + ((Math.PI * 2) / Math.max(roles.length, 1)) * index;
-    const radius = roles.length <= 4 ? 31 : 39;
-    const fallbackLeft = 50 + Math.cos(angle) * radius;
-    const fallbackTop = 50 + Math.sin(angle) * radius;
+    const position = getPresetPosition(roles.length, index);
 
     return {
-      role,
+      id: role,
       label: formatRoleLabel(role),
       status,
       directiveMode,
@@ -125,25 +176,13 @@ function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
       durationMs: totalDuration || undefined,
       credits: totalCredits || undefined,
       stepCount: steps.length,
-      x: preset?.[0] ?? fallbackLeft,
-      y: preset?.[1] ?? fallbackTop,
+      x: position.x,
+      y: position.y,
     };
   });
 }
 
-function formatDirectiveMode(mode?: DirectiveMode) {
-  if (!mode) {
-    return 'Steady';
-  }
-
-  if (mode === 'promote') {
-    return 'Promoted';
-  }
-
-  return mode.charAt(0).toUpperCase() + mode.slice(1);
-}
-
-function getBottleneckRole(replay: Replay, roleNodes: RoleNode[]) {
+function buildLegacyBottleneckId(replay: Replay, nodes: DisplayNode[]) {
   const failedStep = replay.stepExecutions.find((step) => step.status === 'failed');
   if (failedStep?.assignedRole) {
     return failedStep.assignedRole;
@@ -159,23 +198,110 @@ function getBottleneckRole(replay: Replay, roleNodes: RoleNode[]) {
     return matchingExecution.assignedRole;
   }
 
-  return roleNodes.find((node) => node.phases.includes(recommendationPhase))?.role ?? null;
+  return nodes.find((node) => node.phases.includes(recommendationPhase))?.id ?? null;
 }
 
-function buildLinkPath(x: number, y: number) {
+function buildControlPlaneNodes(controlPlane: ControlPlaneSystemState, run: Run): DisplayNode[] {
+  const topology = controlPlane.topology;
+  if (!topology) {
+    return [];
+  }
+
+  const execution = controlPlane.executions.find((item) => item.runId === run.runId) ?? controlPlane.executions[0];
+  const spans = execution ? controlPlane.executionSpans[execution.executionId] ?? [] : [];
+
+  return topology.nodes.map((node, index) => {
+    const agent = node.agentId ? controlPlane.agents.find((item) => item.agentId === node.agentId) : undefined;
+    const nodeSpans = spans.filter((span) => span.nodeId === node.nodeId || (agent?.agentId && span.agentId === agent.agentId));
+    const latestSpan = nodeSpans[nodeSpans.length - 1];
+    const failedSpan = nodeSpans.find((span) => span.status === 'failed');
+    const latestIntervention = [...controlPlane.interventions]
+      .filter((intervention) => intervention.targetScopeType === 'agent' && intervention.targetScopeId === agent?.agentId)
+      .sort((left, right) => right.requestedAt.localeCompare(left.requestedAt))[0];
+    const status: NodeStatus = failedSpan ? 'failed' : nodeSpans.length > 0 ? 'active' : 'standby';
+    const phases = Array.from(new Set(nodeSpans.map((span) => span.kind).concat(agent?.capabilities ?? [])));
+    const credits = nodeSpans.reduce((sum, span) => sum + (span.usage?.credits ?? 0), 0);
+    const durationMs = nodeSpans.reduce((sum, span) => sum + (span.usage?.durationMs ?? 0), 0);
+    const position = getPresetPosition(topology.nodes.length, index);
+    const agentStepCount =
+      agent?.metadata && typeof agent.metadata === 'object' && !Array.isArray(agent.metadata)
+        ? Number((agent.metadata as Record<string, unknown>).stepCount ?? 0)
+        : 0;
+
+    return {
+      id: node.nodeId,
+      label: node.label,
+      status,
+      directiveMode: parseDirectiveMode(latestIntervention?.action),
+      phases,
+      summary:
+        failedSpan?.summary ??
+        latestSpan?.summary ??
+        (typeof agent?.metadata === 'object' && agent?.metadata && !Array.isArray(agent.metadata)
+          ? ((agent.metadata as Record<string, unknown>).workflowId as string | undefined)
+          : undefined) ??
+        `No execution has been recorded for ${node.label} yet.`,
+      durationMs: durationMs || undefined,
+      credits: credits || undefined,
+      stepCount: nodeSpans.length || agentStepCount || 1,
+      x: position.x,
+      y: position.y,
+    };
+  });
+}
+
+function buildControlPlaneEdges(controlPlane: ControlPlaneSystemState): DisplayEdge[] {
+  const topology = controlPlane.topology;
+  if (!topology) {
+    return [];
+  }
+
+  return topology.edges.map((edge: TopologyEdge) => ({
+    id: edge.edgeId,
+    sourceId: edge.sourceNodeId,
+    targetId: edge.targetNodeId,
+  }));
+}
+
+function buildControlPlaneBottleneckId(controlPlane: ControlPlaneSystemState, run: Run, replay: Replay, nodes: DisplayNode[]) {
+  const execution = controlPlane.executions.find((item) => item.runId === run.runId) ?? controlPlane.executions[0];
+  const spans = execution ? controlPlane.executionSpans[execution.executionId] ?? [] : [];
+  const failedSpan = spans.find((span) => span.status === 'failed');
+
+  if (failedSpan?.nodeId) {
+    return failedSpan.nodeId;
+  }
+
+  if (failedSpan?.agentId) {
+    return controlPlane.topology?.nodes.find((node) => node.agentId === failedSpan.agentId)?.nodeId ?? null;
+  }
+
+  const recommendationPhase = replay.operationalContext?.recommendationEvidence[0]?.phase;
+  if (!recommendationPhase) {
+    return null;
+  }
+
+  return nodes.find((node) => node.phases.includes(recommendationPhase))?.id ?? null;
+}
+
+function buildCoreLinkPath(x: number, y: number) {
   const controlX = x < 50 ? 36 : 64;
   const controlY = y < 50 ? 34 : 66;
 
   return `M 50 50 C ${controlX} ${controlY}, ${x} ${y}, ${x} ${y}`;
 }
 
-function getStoredPositions(workflowId: string): Record<string, NodePosition> | null {
+function buildNodeLinkPath(source: NodePosition, target: NodePosition) {
+  return `M ${source.x} ${source.y} Q 50 50 ${target.x} ${target.y}`;
+}
+
+function getStoredPositions(storageKey: string): Record<string, NodePosition> | null {
   if (typeof window === 'undefined') {
     return null;
   }
 
   try {
-    const raw = window.localStorage.getItem(`${POSITION_STORAGE_PREFIX}${workflowId}`);
+    const raw = window.localStorage.getItem(`${POSITION_STORAGE_PREFIX}${storageKey}`);
     if (!raw) {
       return null;
     }
@@ -186,38 +312,38 @@ function getStoredPositions(workflowId: string): Record<string, NodePosition> | 
   }
 }
 
-function storePositions(workflowId: string, positions: Record<string, NodePosition>) {
+function storePositions(storageKey: string, positions: Record<string, NodePosition>) {
   if (typeof window === 'undefined') {
     return;
   }
 
   try {
-    window.localStorage.setItem(`${POSITION_STORAGE_PREFIX}${workflowId}`, JSON.stringify(positions));
+    window.localStorage.setItem(`${POSITION_STORAGE_PREFIX}${storageKey}`, JSON.stringify(positions));
   } catch {
     // Ignore storage failures in demo mode.
   }
 }
 
-function getStoredLayoutMode(workflowId: string): LayoutMode | null {
+function getStoredLayoutMode(storageKey: string): LayoutMode | null {
   if (typeof window === 'undefined') {
     return null;
   }
 
   try {
-    const raw = window.localStorage.getItem(`${MODE_STORAGE_PREFIX}${workflowId}`);
+    const raw = window.localStorage.getItem(`${MODE_STORAGE_PREFIX}${storageKey}`);
     return raw === 'free' || raw === 'orbit' ? raw : null;
   } catch {
     return null;
   }
 }
 
-function storeLayoutMode(workflowId: string, mode: LayoutMode) {
+function storeLayoutMode(storageKey: string, mode: LayoutMode) {
   if (typeof window === 'undefined') {
     return;
   }
 
   try {
-    window.localStorage.setItem(`${MODE_STORAGE_PREFIX}${workflowId}`, mode);
+    window.localStorage.setItem(`${MODE_STORAGE_PREFIX}${storageKey}`, mode);
   } catch {
     // Ignore storage failures in demo mode.
   }
@@ -227,37 +353,44 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
-export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTopologySectionProps) {
-  const roleNodes = buildRoleNodes(workflow, replay);
-  const roleSignature = roleNodes.map((node) => node.role).join('|');
-  const activeCount = roleNodes.filter((node) => node.status === 'active').length;
-  const failedCount = roleNodes.filter((node) => node.status === 'failed').length;
-  const phaseCount = new Set(workflow.steps.map((step) => step.kind)).size;
+export function LiveAgentTopologySection({ workflow, run, replay, controlPlane }: LiveAgentTopologySectionProps) {
+  const topologyNodes = controlPlane ? buildControlPlaneNodes(controlPlane, run) : [];
+  const nodes = topologyNodes.length > 0 ? topologyNodes : buildLegacyNodes(workflow, replay);
+  const edges = controlPlane && topologyNodes.length > 0 ? buildControlPlaneEdges(controlPlane) : [];
+  const nodeSignature = nodes.map((node) => node.id).join('|');
+  const activeCount = nodes.filter((node) => node.status === 'active').length;
+  const failedCount = nodes.filter((node) => node.status === 'failed').length;
+  const phaseCount = new Set(nodes.flatMap((node) => node.phases)).size || new Set(workflow.steps.map((step) => step.kind)).size;
   const similarRun = replay.operationalContext?.similarRuns[0];
   const healthyAnchor = replay.operationalContext?.lastHealthyComparison;
   const recommendation = replay.operationalContext?.recommendationEvidence[0];
-  const directiveCount = Object.keys(replay.studioState?.roleDirectives ?? {}).length;
-  const bottleneckRole = getBottleneckRole(replay, roleNodes);
-  const bottleneckLabel = roleNodes.find((node) => node.role === bottleneckRole)?.label ?? null;
+  const directiveCount = controlPlane
+    ? controlPlane.interventions.filter((intervention) => intervention.action.startsWith('directive.')).length
+    : Object.keys(replay.studioState?.roleDirectives ?? {}).length;
+  const bottleneckId = controlPlane && topologyNodes.length > 0
+    ? buildControlPlaneBottleneckId(controlPlane, run, replay, nodes)
+    : buildLegacyBottleneckId(replay, nodes);
+  const bottleneckLabel = nodes.find((node) => node.id === bottleneckId)?.label ?? null;
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const dragStateRef = useRef<DragState | null>(null);
-  const [draggingRole, setDraggingRole] = useState<string | null>(null);
+  const [draggingNodeId, setDraggingNodeId] = useState<string | null>(null);
   const [nodePositions, setNodePositions] = useState<Record<string, NodePosition>>({});
   const [layoutMode, setLayoutMode] = useState<LayoutMode>('orbit');
+  const storageKey = controlPlane?.system.systemId ?? workflow.workflowId;
 
   useEffect(() => {
-    setLayoutMode(getStoredLayoutMode(workflow.workflowId) ?? 'orbit');
-  }, [workflow.workflowId]);
+    setLayoutMode(getStoredLayoutMode(storageKey) ?? 'orbit');
+  }, [storageKey]);
 
   useEffect(() => {
-    const stored = getStoredPositions(workflow.workflowId);
+    const stored = getStoredPositions(storageKey);
     const nextPositions = Object.fromEntries(
-      roleNodes.map((node) => [
-        node.role,
-        layoutMode === 'free' && stored?.[node.role]
+      nodes.map((node) => [
+        node.id,
+        layoutMode === 'free' && stored?.[node.id]
           ? {
-              x: clamp(stored[node.role].x, 10, 90),
-              y: clamp(stored[node.role].y, 12, 88),
+              x: clamp(stored[node.id].x, 10, 90),
+              y: clamp(stored[node.id].y, 12, 88),
             }
           : {
               x: node.x,
@@ -267,7 +400,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
     );
 
     setNodePositions(nextPositions);
-  }, [workflow.workflowId, roleSignature, layoutMode]);
+  }, [storageKey, nodeSignature, layoutMode]);
 
   useEffect(() => {
     if (!Object.keys(nodePositions).length) {
@@ -275,16 +408,16 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
     }
 
     if (layoutMode === 'free') {
-      storePositions(workflow.workflowId, nodePositions);
+      storePositions(storageKey, nodePositions);
     }
-  }, [layoutMode, nodePositions, workflow.workflowId]);
+  }, [layoutMode, nodePositions, storageKey]);
 
   useEffect(() => {
-    storeLayoutMode(workflow.workflowId, layoutMode);
-  }, [layoutMode, workflow.workflowId]);
+    storeLayoutMode(storageKey, layoutMode);
+  }, [layoutMode, storageKey]);
 
   useEffect(() => {
-    if (!draggingRole || layoutMode !== 'free') {
+    if (!draggingNodeId || layoutMode !== 'free') {
       return;
     }
 
@@ -296,13 +429,12 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
       const rect = canvasRef.current.getBoundingClientRect();
       const paddingX = Math.max(8, Math.min(14, (96 / rect.width) * 100));
       const paddingY = Math.max(10, Math.min(16, (96 / rect.height) * 100));
-
       const x = clamp(((clientX - rect.left) / rect.width) * 100, paddingX, 100 - paddingX);
       const y = clamp(((clientY - rect.top) / rect.height) * 100, paddingY, 100 - paddingY);
 
       setNodePositions((current) => ({
         ...current,
-        [dragStateRef.current!.role]: {
+        [dragStateRef.current!.nodeId]: {
           x,
           y,
         },
@@ -325,7 +457,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
 
       updateFromPointer(event.pointerId, event.clientX, event.clientY);
       dragStateRef.current = null;
-      setDraggingRole(null);
+      setDraggingNodeId(null);
     }
 
     window.addEventListener('pointermove', handlePointerMove, { passive: false });
@@ -337,12 +469,12 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
       window.removeEventListener('pointerup', handlePointerEnd);
       window.removeEventListener('pointercancel', handlePointerEnd);
     };
-  }, [draggingRole]);
+  }, [draggingNodeId, layoutMode]);
 
   function snapToOrbit() {
     const nextPositions = Object.fromEntries(
-      roleNodes.map((node) => [
-        node.role,
+      nodes.map((node) => [
+        node.id,
         {
           x: node.x,
           y: node.y,
@@ -351,16 +483,18 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
     );
 
     dragStateRef.current = null;
-    setDraggingRole(null);
+    setDraggingNodeId(null);
     setNodePositions(nextPositions);
     setLayoutMode('orbit');
   }
 
   function switchToFreeArrange() {
     dragStateRef.current = null;
-    setDraggingRole(null);
+    setDraggingNodeId(null);
     setLayoutMode('free');
   }
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node] as const));
 
   return (
     <section className="surface surface--topology">
@@ -399,65 +533,80 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
         </div>
       </div>
       <p className="feature-summary">
-        This is the piece the standalone demo was missing: the live command core in the middle, the active specialist
-        lanes around it, and the strongest system signals next to the map.
+        {controlPlane
+          ? 'This topology now reads the control-plane model directly: registered agents, topology snapshot, current execution, and recent interventions.'
+          : 'This is the piece the standalone demo was missing: the live command core in the middle, the active specialist lanes around it, and the strongest system signals next to the map.'}
       </p>
       <p className="live-topology__hint">
-        {draggingRole
-          ? `Arranging ${roleNodes.find((node) => node.role === draggingRole)?.label ?? 'agent'}`
+        {draggingNodeId
+          ? `Arranging ${nodes.find((node) => node.id === draggingNodeId)?.label ?? 'agent'}`
           : bottleneckLabel
             ? layoutMode === 'free'
               ? `Current pressure point: ${bottleneckLabel}. Drag any agent card to rearrange the layout, or snap back to orbit at any time.`
               : `Current pressure point: ${bottleneckLabel}. Switch to Free arrange if you want to move the agents manually.`
             : layoutMode === 'free'
-              ? 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this workflow.'
+              ? 'Drag any agent card to rearrange the operating layout. Your layout stays in the browser for this system.'
               : 'Orbit mode keeps the topology in its canonical layout. Switch to Free arrange to move the agents manually.'}
       </p>
 
       <div className="live-topology">
         <div
           ref={canvasRef}
-          className={`live-topology__canvas ${layoutMode === 'free' ? 'live-topology__canvas--free' : 'live-topology__canvas--orbit'} ${draggingRole ? 'live-topology__canvas--dragging' : ''}`}
+          className={`live-topology__canvas ${layoutMode === 'free' ? 'live-topology__canvas--free' : 'live-topology__canvas--orbit'} ${draggingNodeId ? 'live-topology__canvas--dragging' : ''}`}
         >
           <div className="live-topology__orbit live-topology__orbit--outer" />
           <div className="live-topology__orbit live-topology__orbit--inner" />
           <div className="live-topology__glow" />
           <svg className="live-topology__links" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-            {roleNodes.map((node, index) => {
-              const position = nodePositions[node.role] ?? { x: node.x, y: node.y };
-              const isBottleneck = node.role === bottleneckRole;
-              const isDragged = draggingRole === node.role;
-              const path = buildLinkPath(position.x, position.y);
+            {(edges.length > 0
+              ? edges.map((edge, index) => ({ edge, index }))
+              : nodes.map((node, index) => ({ edge: { id: `core-${node.id}`, sourceId: 'core', targetId: node.id }, index }))
+            ).map(({ edge, index }) => {
+              const sourceNode = edge.sourceId === 'core' ? null : nodeById.get(edge.sourceId);
+              const sourcePosition =
+                edge.sourceId === 'core'
+                  ? { x: 50, y: 50 }
+                  : nodePositions[edge.sourceId] ?? (sourceNode ? { x: sourceNode.x, y: sourceNode.y } : { x: 50, y: 50 });
+              const targetNode = nodeById.get(edge.targetId);
+              const targetPosition = nodePositions[edge.targetId] ?? (targetNode ? { x: targetNode.x, y: targetNode.y } : { x: 50, y: 50 });
+              const path =
+                edge.sourceId === 'core'
+                  ? buildCoreLinkPath(targetPosition.x, targetPosition.y)
+                  : buildNodeLinkPath(sourcePosition, targetPosition);
+              const touchesBottleneck = edge.sourceId === bottleneckId || edge.targetId === bottleneckId;
+              const touchesDragged = edge.sourceId === draggingNodeId || edge.targetId === draggingNodeId;
+              const failedEdge = sourceNode?.status === 'failed' || targetNode?.status === 'failed';
+              const activeEdge = sourceNode?.status === 'active' || targetNode?.status === 'active' || edge.sourceId === 'core';
               const toneClass =
-                node.status === 'failed'
+                failedEdge
                   ? 'live-topology__link--failed'
-                  : isDragged
+                  : touchesDragged
                     ? 'live-topology__link--dragging'
-                  : isBottleneck
-                    ? 'live-topology__link--bottleneck'
-                    : node.status === 'active'
-                      ? 'live-topology__link--active'
-                      : 'live-topology__link--standby';
+                    : touchesBottleneck
+                      ? 'live-topology__link--bottleneck'
+                      : activeEdge
+                        ? 'live-topology__link--active'
+                        : 'live-topology__link--standby';
 
               return (
-                <g key={`link-${node.role}`}>
+                <g key={`link-${edge.id}`}>
                   <path className={`live-topology__link live-topology__link-glow ${toneClass}`} d={path} />
                   <path className={`live-topology__link live-topology__link-line ${toneClass}`} d={path} />
-                  {node.status !== 'standby' || isBottleneck ? (
+                  {activeEdge || touchesBottleneck ? (
                     <>
                       <circle
-                        className={`live-topology__packet ${isBottleneck ? 'live-topology__packet--bottleneck' : node.status === 'failed' ? 'live-topology__packet--failed' : 'live-topology__packet--active'} ${isDragged ? 'live-topology__packet--dragging' : ''}`}
-                        r={isBottleneck ? 0.95 : 0.72}
+                        className={`live-topology__packet ${touchesBottleneck ? 'live-topology__packet--bottleneck' : failedEdge ? 'live-topology__packet--failed' : 'live-topology__packet--active'} ${touchesDragged ? 'live-topology__packet--dragging' : ''}`}
+                        r={touchesBottleneck ? 0.95 : 0.72}
                       >
                         <animateMotion
                           path={path}
-                          dur={isDragged ? '1.6s' : isBottleneck ? '2.1s' : '3.2s'}
+                          dur={touchesDragged ? '1.6s' : touchesBottleneck ? '2.1s' : '3.2s'}
                           begin={`${index * 0.35}s`}
                           repeatCount="indefinite"
                           rotate="auto"
                         />
                       </circle>
-                      {isBottleneck ? (
+                      {touchesBottleneck ? (
                         <circle className="live-topology__packet live-topology__packet--bottleneck" r={0.62}>
                           <animateMotion
                             path={path}
@@ -476,8 +625,8 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
           </svg>
           <div className="live-topology__core">
             <p className="eyebrow">Control core</p>
-            <strong>{workflow.name}</strong>
-            <p>{workflow.description ?? 'Multi-agent workflow with a guarded operator loop.'}</p>
+            <strong>{controlPlane?.system.name ?? workflow.name}</strong>
+            <p>{controlPlane?.system.description ?? workflow.description ?? 'Multi-agent workflow with a guarded operator loop.'}</p>
             <div className="live-topology__core-meta">
               <span className="meta-chip">{workflow.policy?.optimizationGoal?.replace('_', ' ') ?? 'balanced'}</span>
               <span className="meta-chip">{workflow.policy?.reviewPolicy ?? 'standard'} review</span>
@@ -485,14 +634,14 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
             </div>
           </div>
 
-          {roleNodes.map((node, index) => {
-            const position = nodePositions[node.role] ?? { x: node.x, y: node.y };
-            const isDragging = draggingRole === node.role;
-            const isBottleneck = node.role === bottleneckRole;
+          {nodes.map((node, index) => {
+            const position = nodePositions[node.id] ?? { x: node.x, y: node.y };
+            const isDragging = draggingNodeId === node.id;
+            const isBottleneck = node.id === bottleneckId;
 
             return (
               <article
-                key={node.role}
+                key={node.id}
                 className={`live-node live-node--${node.status} ${isBottleneck ? 'live-node--bottleneck' : ''} ${isDragging ? 'live-node--dragging' : ''}`}
                 style={{
                   left: `${position.x}%`,
@@ -506,16 +655,16 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
                   }
 
                   dragStateRef.current = {
-                    role: node.role,
+                    nodeId: node.id,
                     pointerId: event.pointerId,
                   };
-                  setDraggingRole(node.role);
+                  setDraggingNodeId(node.id);
                 }}
               >
                 <div className="live-node__header">
                   <div>
                     <p className="live-node__label">{node.label}</p>
-                    <p className="live-node__meta">{node.stepCount} mapped steps</p>
+                    <p className="live-node__meta">{node.stepCount} tracked events</p>
                   </div>
                   <span className={`live-node__status live-node__status--${node.status}`} />
                 </div>
@@ -524,7 +673,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
                 <div className="live-node__tags">
                   <span className="meta-chip">{formatDirectiveMode(node.directiveMode)}</span>
                   {node.phases.slice(0, 2).map((phase) => (
-                    <span key={`${node.role}-${phase}`} className="meta-chip">
+                    <span key={`${node.id}-${phase}`} className="meta-chip">
                       {phase}
                     </span>
                   ))}
@@ -565,7 +714,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
 
       <div className="live-topology__footer">
         <div className="mini-surface live-topology__stat">
-          <p className="eyebrow">Active roles</p>
+          <p className="eyebrow">Active agents</p>
           <strong>{activeCount}</strong>
         </div>
         <div className="mini-surface live-topology__stat">
@@ -573,7 +722,7 @@ export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTop
           <strong>{failedCount}</strong>
         </div>
         <div className="mini-surface live-topology__stat">
-          <p className="eyebrow">Workflow phases</p>
+          <p className="eyebrow">Tracked phases</p>
           <strong>{phaseCount}</strong>
         </div>
         <div className="mini-surface live-topology__stat">

--- a/apps/web/src/features/live/LiveAgentTopologySection.tsx
+++ b/apps/web/src/features/live/LiveAgentTopologySection.tsx
@@ -1,0 +1,216 @@
+import type { DirectiveMode, Replay, Run, Workflow, WorkflowStep } from '@agent-studio/contracts';
+
+import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
+
+interface LiveAgentTopologySectionProps {
+  workflow: Workflow;
+  run: Run;
+  replay: Replay;
+}
+
+type RoleNodeStatus = 'active' | 'failed' | 'standby';
+
+type RoleNode = {
+  role: string;
+  label: string;
+  status: RoleNodeStatus;
+  directiveMode?: DirectiveMode;
+  phases: string[];
+  summary: string;
+  durationMs?: number;
+  credits?: number;
+  stepCount: number;
+  left: string;
+  top: string;
+};
+
+function formatRoleLabel(role: string) {
+  return role
+    .split(/[-_ ]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
+  const workflowStepsByRole = new Map<string, WorkflowStep[]>();
+
+  for (const step of workflow.steps) {
+    const steps = workflowStepsByRole.get(step.assignedRole) ?? [];
+    steps.push(step);
+    workflowStepsByRole.set(step.assignedRole, steps);
+  }
+
+  const roles = Array.from(workflowStepsByRole.entries());
+
+  return roles.map(([role, steps], index) => {
+    const executedSteps = replay.stepExecutions.filter((step) => step.assignedRole === role);
+    const directiveMode =
+      replay.studioState?.roleDirectives?.[role]?.mode ?? executedSteps.find((step) => step.directiveMode)?.directiveMode;
+
+    const failedStep = executedSteps.find((step) => step.status === 'failed');
+    const activeStep = executedSteps.find((step) => step.status === 'running') ?? executedSteps[executedSteps.length - 1];
+
+    const status: RoleNodeStatus = failedStep
+      ? 'failed'
+      : executedSteps.some((step) => step.status === 'running' || step.status === 'succeeded')
+        ? 'active'
+        : 'standby';
+
+    const totalCredits = executedSteps.reduce((sum, step) => sum + (step.actualCredits ?? 0), 0);
+    const totalDuration = executedSteps.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
+    const phases = Array.from(new Set(steps.map((step) => step.kind)));
+    const angle = (-Math.PI / 2) + ((Math.PI * 2) / Math.max(roles.length, 1)) * index;
+    const radius = roles.length <= 4 ? 31 : 35;
+
+    return {
+      role,
+      label: formatRoleLabel(role),
+      status,
+      directiveMode,
+      phases,
+      summary:
+        failedStep?.error ??
+        failedStep?.summary ??
+        activeStep?.summary ??
+        steps[0]?.objective ??
+        'No activity summary available.',
+      durationMs: totalDuration || undefined,
+      credits: totalCredits || undefined,
+      stepCount: steps.length,
+      left: `${50 + Math.cos(angle) * radius}%`,
+      top: `${50 + Math.sin(angle) * radius}%`,
+    };
+  });
+}
+
+function formatDirectiveMode(mode?: DirectiveMode) {
+  if (!mode) {
+    return 'Steady';
+  }
+
+  if (mode === 'promote') {
+    return 'Promoted';
+  }
+
+  return mode.charAt(0).toUpperCase() + mode.slice(1);
+}
+
+export function LiveAgentTopologySection({ workflow, run, replay }: LiveAgentTopologySectionProps) {
+  const roleNodes = buildRoleNodes(workflow, replay);
+  const activeCount = roleNodes.filter((node) => node.status === 'active').length;
+  const failedCount = roleNodes.filter((node) => node.status === 'failed').length;
+  const phaseCount = new Set(workflow.steps.map((step) => step.kind)).size;
+  const similarRun = replay.operationalContext?.similarRuns[0];
+  const healthyAnchor = replay.operationalContext?.lastHealthyComparison;
+  const recommendation = replay.operationalContext?.recommendationEvidence[0];
+  const directiveCount = Object.keys(replay.studioState?.roleDirectives ?? {}).length;
+
+  return (
+    <section className="surface surface--topology">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Live agent topology</p>
+          <h3>Working agents and command flow</h3>
+        </div>
+        <span className={`status-pill status-pill--${failedCount > 0 ? 'failed' : run.status}`}>
+          {failedCount > 0 ? 'Pressure visible' : titleCaseStatus(run.status)}
+        </span>
+      </div>
+      <p className="feature-summary">
+        This is the piece the standalone demo was missing: the live command core in the middle, the active specialist
+        lanes around it, and the strongest system signals next to the map.
+      </p>
+
+      <div className="live-topology">
+        <div className="live-topology__canvas">
+          <div className="live-topology__orbit live-topology__orbit--outer" />
+          <div className="live-topology__orbit live-topology__orbit--inner" />
+          <div className="live-topology__glow" />
+          <div className="live-topology__core">
+            <p className="eyebrow">Control core</p>
+            <strong>{workflow.name}</strong>
+            <p>{workflow.description ?? 'Multi-agent workflow with a guarded operator loop.'}</p>
+            <div className="live-topology__core-meta">
+              <span className="meta-chip">{workflow.policy?.optimizationGoal?.replace('_', ' ') ?? 'balanced'}</span>
+              <span className="meta-chip">{workflow.policy?.reviewPolicy ?? 'standard'} review</span>
+              <span className="meta-chip">{formatCredits(run.actualCredits)}</span>
+            </div>
+          </div>
+
+          {roleNodes.map((node) => (
+            <article
+              key={node.role}
+              className={`live-node live-node--${node.status}`}
+              style={{ left: node.left, top: node.top }}
+            >
+              <div className="live-node__header">
+                <div>
+                  <p className="live-node__label">{node.label}</p>
+                  <p className="live-node__meta">{node.stepCount} mapped steps</p>
+                </div>
+                <span className={`live-node__status live-node__status--${node.status}`} />
+              </div>
+              <p className="live-node__summary">{node.summary}</p>
+              <div className="live-node__tags">
+                <span className="meta-chip">{formatDirectiveMode(node.directiveMode)}</span>
+                {node.phases.slice(0, 2).map((phase) => (
+                  <span key={`${node.role}-${phase}`} className="meta-chip">
+                    {phase}
+                  </span>
+                ))}
+              </div>
+              <div className="live-node__metrics">
+                <span>{formatCredits(node.credits)}</span>
+                <span>{formatDuration(node.durationMs)}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="live-topology__rail">
+          <article className="signal-card signal-card--cyan">
+            <p className="eyebrow">Pressure read</p>
+            <strong>{recommendation?.title ?? 'Healthy operator loop'}</strong>
+            <p>{recommendation?.body ?? 'The live run is stable enough to use as the healthy anchor for future replay work.'}</p>
+          </article>
+
+          <article className="signal-card signal-card--violet">
+            <p className="eyebrow">Closest prior signal</p>
+            <strong>{similarRun?.label ?? 'No related run yet'}</strong>
+            <p>
+              {similarRun
+                ? `${(similarRun.similarityScore * 100).toFixed(0)}% match across ${similarRun.matchedSignals.slice(0, 2).join(', ')}.`
+                : 'Once more runs land, similar-run recall will appear here.'}
+            </p>
+          </article>
+
+          <article className="signal-card signal-card--gold">
+            <p className="eyebrow">Healthy anchor</p>
+            <strong>{healthyAnchor?.label ?? 'Current run is the anchor'}</strong>
+            <p>{healthyAnchor?.summary ?? 'This run is the strongest baseline currently available in the demo.'}</p>
+          </article>
+        </div>
+      </div>
+
+      <div className="live-topology__footer">
+        <div className="mini-surface live-topology__stat">
+          <p className="eyebrow">Active roles</p>
+          <strong>{activeCount}</strong>
+        </div>
+        <div className="mini-surface live-topology__stat">
+          <p className="eyebrow">Pressure lanes</p>
+          <strong>{failedCount}</strong>
+        </div>
+        <div className="mini-surface live-topology__stat">
+          <p className="eyebrow">Workflow phases</p>
+          <strong>{phaseCount}</strong>
+        </div>
+        <div className="mini-surface live-topology__stat">
+          <p className="eyebrow">Directive load</p>
+          <strong>{directiveCount}</strong>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/live/LiveAgentTopologySection.tsx
+++ b/apps/web/src/features/live/LiveAgentTopologySection.tsx
@@ -24,6 +24,33 @@ type RoleNode = {
   top: string;
 };
 
+const POSITION_PRESETS: Record<number, Array<[number, number]>> = {
+  1: [[50, 18]],
+  2: [[24, 34], [76, 34]],
+  3: [[50, 18], [24, 62], [76, 62]],
+  4: [
+    [20, 28],
+    [74, 28],
+    [74, 68],
+    [20, 68],
+  ],
+  5: [
+    [50, 16],
+    [18, 34],
+    [76, 34],
+    [68, 72],
+    [26, 72],
+  ],
+  6: [
+    [50, 15],
+    [18, 28],
+    [76, 28],
+    [76, 66],
+    [50, 79],
+    [18, 66],
+  ],
+};
+
 function formatRoleLabel(role: string) {
   return role
     .split(/[-_ ]+/)
@@ -60,8 +87,11 @@ function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
     const totalCredits = executedSteps.reduce((sum, step) => sum + (step.actualCredits ?? 0), 0);
     const totalDuration = executedSteps.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
     const phases = Array.from(new Set(steps.map((step) => step.kind)));
+    const preset = POSITION_PRESETS[roles.length]?.[index];
     const angle = (-Math.PI / 2) + ((Math.PI * 2) / Math.max(roles.length, 1)) * index;
-    const radius = roles.length <= 4 ? 31 : 35;
+    const radius = roles.length <= 4 ? 31 : 39;
+    const fallbackLeft = 50 + Math.cos(angle) * radius;
+    const fallbackTop = 50 + Math.sin(angle) * radius;
 
     return {
       role,
@@ -78,8 +108,8 @@ function buildRoleNodes(workflow: Workflow, replay: Replay): RoleNode[] {
       durationMs: totalDuration || undefined,
       credits: totalCredits || undefined,
       stepCount: steps.length,
-      left: `${50 + Math.cos(angle) * radius}%`,
-      top: `${50 + Math.sin(angle) * radius}%`,
+      left: `${preset?.[0] ?? fallbackLeft}%`,
+      top: `${preset?.[1] ?? fallbackTop}%`,
     };
   });
 }

--- a/apps/web/src/features/live/LivePanel.tsx
+++ b/apps/web/src/features/live/LivePanel.tsx
@@ -1,6 +1,7 @@
 import type { Replay, Run, Workflow } from '@agent-studio/contracts';
 
 import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
+import { LiveAgentTopologySection } from './LiveAgentTopologySection';
 
 interface LivePanelProps {
   workflow: Workflow;
@@ -10,10 +11,13 @@ interface LivePanelProps {
 
 export function LivePanel({ workflow, run, replay }: LivePanelProps) {
   const topSignal = replay.operationalContext?.similarRuns[0];
+  const healthyAnchor = replay.operationalContext?.lastHealthyComparison;
+  const recommendation = replay.operationalContext?.recommendationEvidence[0];
+  const directiveCount = Object.keys(replay.studioState?.roleDirectives ?? {}).length;
 
   return (
     <div className="room-stack">
-      <section className="surface">
+      <section className="surface surface--live-brief">
         <div className="section-header">
           <div>
             <p className="eyebrow">Current posture</p>
@@ -43,6 +47,23 @@ export function LivePanel({ workflow, run, replay }: LivePanelProps) {
           {replay.stepExecutions[0]?.summary} The run finished with a safe publish path and gives the public demo a stable
           “healthy now” state to orient around.
         </p>
+        <div className="signal-band">
+          <article className="signal-band__card">
+            <p className="eyebrow">Healthy anchor</p>
+            <strong>{healthyAnchor?.label ?? run.experimentLabel}</strong>
+            <p>{healthyAnchor?.summary ?? 'This run is currently the strongest baseline in the demo loop.'}</p>
+          </article>
+          <article className="signal-band__card signal-band__card--accent">
+            <p className="eyebrow">Recommendation</p>
+            <strong>{recommendation?.title ?? 'Operator loop is stable'}</strong>
+            <p>{recommendation?.body ?? 'No urgent intervention needed. Use Replay for explanation and Optimize for release work.'}</p>
+          </article>
+          <article className="signal-band__card signal-band__card--directive">
+            <p className="eyebrow">Directive load</p>
+            <strong>{directiveCount} tuned roles</strong>
+            <p>Role directives stay visible so the operator can see how much steering the system is carrying right now.</p>
+          </article>
+        </div>
         {topSignal ? (
           <div className="inline-callout">
             <span className="eyebrow">Best next hop</span>
@@ -54,10 +75,12 @@ export function LivePanel({ workflow, run, replay }: LivePanelProps) {
         ) : null}
       </section>
 
-      <section className="surface">
+      <LiveAgentTopologySection workflow={workflow} run={run} replay={replay} />
+
+      <section className="surface surface--sequence">
         <div className="section-header">
           <div>
-            <p className="eyebrow">Workflow map</p>
+            <p className="eyebrow">Execution lane</p>
             <h3>Live sequence</h3>
           </div>
           <span className="meta-chip">{workflow.steps.length} steps</span>

--- a/apps/web/src/features/live/LivePanel.tsx
+++ b/apps/web/src/features/live/LivePanel.tsx
@@ -1,3 +1,4 @@
+import type { ControlPlaneSystemState } from '../../app/control-plane';
 import type { Replay, Run, Workflow } from '@agent-studio/contracts';
 
 import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
@@ -7,13 +8,17 @@ interface LivePanelProps {
   workflow: Workflow;
   run: Run;
   replay: Replay;
+  controlPlane?: ControlPlaneSystemState | null;
 }
 
-export function LivePanel({ workflow, run, replay }: LivePanelProps) {
+export function LivePanel({ workflow, run, replay, controlPlane }: LivePanelProps) {
   const topSignal = replay.operationalContext?.similarRuns[0];
   const healthyAnchor = replay.operationalContext?.lastHealthyComparison;
   const recommendation = replay.operationalContext?.recommendationEvidence[0];
   const directiveCount = Object.keys(replay.studioState?.roleDirectives ?? {}).length;
+  const systemAgentCount = controlPlane?.agents.length ?? null;
+  const systemExecutionCount = controlPlane?.executions.length ?? null;
+  const systemReleaseCount = controlPlane?.releases.length ?? null;
 
   return (
     <div className="room-stack">
@@ -73,9 +78,19 @@ export function LivePanel({ workflow, run, replay }: LivePanelProps) {
             </p>
           </div>
         ) : null}
+        {controlPlane ? (
+          <div className="inline-callout">
+            <span className="eyebrow">Control-plane view</span>
+            <p>
+              This workflow now maps to <strong>{controlPlane.system.name}</strong> with{' '}
+              <strong>{systemAgentCount}</strong> registered agents, <strong>{systemExecutionCount}</strong> tracked
+              executions, and <strong>{systemReleaseCount}</strong> recorded release decisions.
+            </p>
+          </div>
+        ) : null}
       </section>
 
-      <LiveAgentTopologySection workflow={workflow} run={run} replay={replay} />
+      <LiveAgentTopologySection workflow={workflow} run={run} replay={replay} controlPlane={controlPlane} />
 
       <section className="surface surface--sequence">
         <div className="section-header">

--- a/apps/web/src/features/live/LivePanel.tsx
+++ b/apps/web/src/features/live/LivePanel.tsx
@@ -19,6 +19,14 @@ export function LivePanel({ workflow, run, replay, controlPlane }: LivePanelProp
   const systemAgentCount = controlPlane?.agents.length ?? null;
   const systemExecutionCount = controlPlane?.executions.length ?? null;
   const systemReleaseCount = controlPlane?.releases.length ?? null;
+  const postureSummary =
+    replay.stepExecutions[0]?.summary ??
+    recommendation?.body ??
+    (run.status === 'planned'
+      ? 'This system is registered and ready for its first traced execution.'
+      : controlPlane
+        ? 'This room is reading live execution state directly from imported control-plane data.'
+        : 'This room is reading the seeded workflow projection.');
 
   return (
     <div className="room-stack">
@@ -49,8 +57,7 @@ export function LivePanel({ workflow, run, replay, controlPlane }: LivePanelProp
           </div>
         </div>
         <p className="feature-summary">
-          {replay.stepExecutions[0]?.summary} The run finished with a safe publish path and gives the public demo a stable
-          “healthy now” state to orient around.
+          {postureSummary}
         </p>
         <div className="signal-band">
           <article className="signal-band__card">

--- a/apps/web/src/features/onboarding/OnboardingPanel.tsx
+++ b/apps/web/src/features/onboarding/OnboardingPanel.tsx
@@ -77,6 +77,8 @@ export function OnboardingPanel({ onDismiss, controlPlaneState, systemState, run
           </>
         ) : null}
         .
+        {' '}
+        <strong>Storage:</strong> {controlPlaneState?.storage.mode === 'file' ? 'persistent file-backed registry' : 'ephemeral in-memory demo store'}.
       </div>
     </section>
   );

--- a/apps/web/src/features/onboarding/OnboardingPanel.tsx
+++ b/apps/web/src/features/onboarding/OnboardingPanel.tsx
@@ -1,32 +1,49 @@
+import type { ControlPlaneState, ControlPlaneSystemState } from '../../app/control-plane';
+
 interface OnboardingPanelProps {
   onDismiss: () => void;
+  controlPlaneState?: ControlPlaneState | null;
+  systemState?: ControlPlaneSystemState | null;
+  runtimeLabel?: string | null;
 }
 
-const LOOP_STEPS = [
+const OPERATOR_STEPS = [
   {
-    title: '1. Live',
-    body: 'Inspect the current operating state and find the one signal that deserves attention.',
+    title: '1. Register the runtime',
+    body: 'Post a runtime and system first so Studio has a durable home for your agent network.',
   },
   {
-    title: '2. Replay',
-    body: 'Explain exactly why a run broke or improved and identify the real decision point.',
+    title: '2. Ingest real traces',
+    body: 'Send agents, topology, executions, spans, and metrics so Live and Replay stop guessing.',
   },
   {
-    title: '3. Optimize',
-    body: 'Compare the candidate against the healthy control and make the release call.',
+    title: '3. Tune and release',
+    body: 'Use interventions, evaluations, and release decisions to make Studio an operating surface instead of a viewer.',
   },
 ];
 
-export function OnboardingPanel({ onDismiss }: OnboardingPanelProps) {
+export function OnboardingPanel({ onDismiss, controlPlaneState, systemState, runtimeLabel }: OnboardingPanelProps) {
+  const spanCount = Object.values(systemState?.executionSpans ?? {}).reduce((total, spans) => total + spans.length, 0);
+  const ingestChecks = [
+    { label: 'Runtimes', value: controlPlaneState?.runtimes.length ?? 0 },
+    { label: 'Systems', value: controlPlaneState?.systems.length ?? 0 },
+    { label: 'Agents', value: systemState?.agents.length ?? 0 },
+    { label: 'Topology', value: systemState?.topology ? 1 : 0 },
+    { label: 'Executions', value: systemState?.executions.length ?? 0 },
+    { label: 'Spans', value: spanCount },
+    { label: 'Interventions', value: systemState?.interventions.length ?? 0 },
+    { label: 'Releases', value: systemState?.releases.length ?? 0 },
+  ];
+
   return (
     <section className="surface onboarding-panel">
       <div className="onboarding-panel__header">
         <div>
           <p className="eyebrow">First run</p>
-          <h2>How Agent Studio works</h2>
+          <h2>Connect your own multi-agent system</h2>
           <p className="muted">
-            Studio is not where you author the workflow. It is where you operate the system, explain a run, and decide
-            whether the next candidate should ship.
+            Agent Studio is not where you author the runtime. It is where you register the system, verify ingest health,
+            operate traces, and decide what should change next.
           </p>
         </div>
         <button className="ghost-button" type="button" onClick={onDismiss}>
@@ -34,16 +51,32 @@ export function OnboardingPanel({ onDismiss }: OnboardingPanelProps) {
         </button>
       </div>
       <div className="loop-grid">
-        {LOOP_STEPS.map((step) => (
+        {OPERATOR_STEPS.map((step) => (
           <article key={step.title} className="loop-grid__card">
             <h3>{step.title}</h3>
             <p>{step.body}</p>
           </article>
         ))}
       </div>
+      <div className="ingest-grid">
+        {ingestChecks.map((check) => (
+          <article key={check.label} className={`ingest-card ${check.value > 0 ? 'ingest-card--ready' : 'ingest-card--thin'}`}>
+            <span>{check.label}</span>
+            <strong>{check.value}</strong>
+          </article>
+        ))}
+      </div>
       <div className="boundary-note">
-        <strong>Why rooms exist:</strong> they keep observing, diagnosing, and releasing separate so the operator loop
-        stays fast and readable.
+        <strong>Current connection path:</strong> POST to the `/api/control/ingest/*` routes for runtimes, systems,
+        agents, topology, executions, spans, metrics, interventions, evaluations, and releases. The seeded demo is
+        currently loaded as <strong>{systemState?.system.name ?? 'the demo system'}</strong>
+        {runtimeLabel ? (
+          <>
+            {' '}
+            on <strong>{runtimeLabel}</strong>
+          </>
+        ) : null}
+        .
       </div>
     </section>
   );

--- a/apps/web/src/features/optimize/OptimizeAdvancedPanel.tsx
+++ b/apps/web/src/features/optimize/OptimizeAdvancedPanel.tsx
@@ -1,11 +1,18 @@
 import type { PromotionEvent, SavedPlan } from '@agent-studio/contracts';
 
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { getLatestEvaluation, getLatestReleaseDecision } from '../../app/control-plane';
+
 interface OptimizeAdvancedPanelProps {
   savedPlans: SavedPlan[];
   promotionHistory: PromotionEvent[];
+  controlPlane?: ControlPlaneSystemState | null;
 }
 
-export function OptimizeAdvancedPanel({ savedPlans, promotionHistory }: OptimizeAdvancedPanelProps) {
+export function OptimizeAdvancedPanel({ savedPlans, promotionHistory, controlPlane }: OptimizeAdvancedPanelProps) {
+  const latestEvaluation = getLatestEvaluation(controlPlane);
+  const latestRelease = getLatestReleaseDecision(controlPlane);
+
   return (
     <div className="advanced-grid">
       <section className="mini-surface">
@@ -30,6 +37,25 @@ export function OptimizeAdvancedPanel({ savedPlans, promotionHistory }: Optimize
           ))}
         </div>
       </section>
+      {latestEvaluation || latestRelease ? (
+        <section className="mini-surface">
+          <p className="eyebrow">Control-plane release audit</p>
+          <div className="stack-list">
+            {latestEvaluation ? (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>{latestEvaluation.verdict}</strong>
+                <p>{latestEvaluation.summary ?? 'No evaluation summary recorded.'}</p>
+              </div>
+            ) : null}
+            {latestRelease ? (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>{latestRelease.decision}</strong>
+                <p>{latestRelease.summary ?? 'No release summary recorded.'}</p>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/optimize/OptimizeAdvancedPanel.tsx
+++ b/apps/web/src/features/optimize/OptimizeAdvancedPanel.tsx
@@ -1,7 +1,8 @@
 import type { PromotionEvent, SavedPlan } from '@agent-studio/contracts';
 
 import type { ControlPlaneSystemState } from '../../app/control-plane';
-import { getLatestEvaluation, getLatestReleaseDecision } from '../../app/control-plane';
+import { getAgentLabel, getLatestEvaluation, getLatestReleaseDecision } from '../../app/control-plane';
+import { formatCredits, formatDateTime, formatDelta, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface OptimizeAdvancedPanelProps {
   savedPlans: SavedPlan[];
@@ -9,53 +10,261 @@ interface OptimizeAdvancedPanelProps {
   controlPlane?: ControlPlaneSystemState | null;
 }
 
+function formatTokenLabel(value: string) {
+  return value
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+function sortByNewest<T>(items: T[], getTimestamp: (item: T) => string | undefined) {
+  return [...items].sort((left, right) => {
+    const leftValue = getTimestamp(left);
+    const rightValue = getTimestamp(right);
+
+    if (leftValue && rightValue) {
+      return rightValue.localeCompare(leftValue);
+    }
+
+    if (rightValue) {
+      return 1;
+    }
+
+    if (leftValue) {
+      return -1;
+    }
+
+    return 0;
+  });
+}
+
+function readMetadataNumber(metadata: unknown, key: string) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+
+  return typeof value === 'number' ? value : null;
+}
+
+function readMetadataString(metadata: unknown, key: string) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+
+  return typeof value === 'string' ? value : null;
+}
+
+function readConfigPatchPhases(configPatch: unknown) {
+  if (!configPatch || typeof configPatch !== 'object' || Array.isArray(configPatch)) {
+    return [];
+  }
+
+  const phases = (configPatch as Record<string, unknown>).phases;
+
+  return Array.isArray(phases) ? phases.filter((phase): phase is string => typeof phase === 'string') : [];
+}
+
+function formatMetricValue(metric: string, value?: number | null, unit?: string) {
+  if (value == null) {
+    return '—';
+  }
+
+  if (metric === 'credits.actual') {
+    return formatCredits(value);
+  }
+
+  if (metric === 'duration.ms') {
+    return formatDuration(value);
+  }
+
+  return unit ? `${value} ${unit}` : `${value}`;
+}
+
+function formatMetricDelta(metric: string, value?: number | null, unit?: string) {
+  if (value == null) {
+    return '—';
+  }
+
+  if (metric === 'credits.actual') {
+    return `${formatDelta(value)} cr`;
+  }
+
+  if (metric === 'duration.ms') {
+    return `${formatDelta(Math.round(value / 1000))}s`;
+  }
+
+  return unit ? `${formatDelta(value)} ${unit}` : formatDelta(value);
+}
+
 export function OptimizeAdvancedPanel({ savedPlans, promotionHistory, controlPlane }: OptimizeAdvancedPanelProps) {
   const latestEvaluation = getLatestEvaluation(controlPlane);
   const latestRelease = getLatestReleaseDecision(controlPlane);
+  const recentInterventions = (controlPlane?.interventions ?? []).slice(0, 4);
+  const recentPlans = sortByNewest(savedPlans, (plan) => plan.createdAt).slice(0, 3);
+  const recentPromotions = sortByNewest(promotionHistory, (promotion) => promotion.appliedAt).slice(0, 4);
+  const releaseMode = readMetadataString(latestRelease?.metadata, 'mode');
+  const releaseConfidence = readMetadataNumber(latestRelease?.metadata, 'confidence');
+  const releaseCreditsDelta = readMetadataNumber(latestRelease?.metadata, 'creditsDelta');
+  const releaseDurationDelta = readMetadataNumber(latestRelease?.metadata, 'durationDelta');
+  const releaseSuccessDelta = readMetadataNumber(latestRelease?.metadata, 'successDelta');
 
   return (
     <div className="advanced-grid">
       <section className="mini-surface">
-        <p className="eyebrow">Saved plans</p>
+        <p className="eyebrow">Latest evaluation</p>
         <div className="stack-list">
-          {savedPlans.map((plan) => (
-            <div key={plan.id} className="stack-list__item stack-list__item--body">
-              <strong>{plan.name}</strong>
-              <p>{plan.notes ?? 'No notes recorded.'}</p>
+          <div className="stack-list__item stack-list__item--body">
+            <strong>{latestEvaluation ? `${titleCaseStatus(latestEvaluation.verdict)} verdict` : 'Saved candidate fallback'}</strong>
+            <p>{latestEvaluation?.summary ?? recentPlans[0]?.notes ?? 'No evaluation summary recorded.'}</p>
+            <div className="optimize-record__meta">
+              <span className="meta-chip">{latestEvaluation ? formatDateTime(latestEvaluation.createdAt) : 'Saved plan'}</span>
+              <span className="meta-chip">
+                {latestEvaluation ? `${latestEvaluation.baselineRefs.length} baseline ref${latestEvaluation.baselineRefs.length === 1 ? '' : 's'}` : 'No baseline refs'}
+              </span>
+              <span className="meta-chip">
+                {latestEvaluation ? `${latestEvaluation.candidateRefs.length} candidate ref${latestEvaluation.candidateRefs.length === 1 ? '' : 's'}` : 'No candidate refs'}
+              </span>
             </div>
-          ))}
+          </div>
+          {latestEvaluation?.metricDeltas?.length ? (
+            latestEvaluation.metricDeltas.map((metric) => (
+              <div key={metric.metric} className="stack-list__item stack-list__item--body">
+                <strong>{formatTokenLabel(metric.metric)}</strong>
+                <p>
+                  Baseline {formatMetricValue(metric.metric, metric.baselineValue, metric.unit)} · Candidate{' '}
+                  {formatMetricValue(metric.metric, metric.candidateValue, metric.unit)} · Delta{' '}
+                  {formatMetricDelta(metric.metric, metric.delta, metric.unit)}
+                </p>
+              </div>
+            ))
+          ) : (
+            <div className="stack-list__item stack-list__item--body">
+              <strong>No metric deltas</strong>
+              <p>Falling back to the saved candidate plan and promotion story until the control plane records an evaluation.</p>
+            </div>
+          )}
         </div>
       </section>
+
+      <section className="mini-surface">
+        <p className="eyebrow">Release evidence</p>
+        <div className="stack-list">
+          <div className="stack-list__item stack-list__item--body">
+            <strong>{latestRelease ? `${formatTokenLabel(latestRelease.decision)} release` : 'Promotion history fallback'}</strong>
+            <p>{latestRelease?.summary ?? recentPromotions[0]?.summary ?? 'No release summary recorded.'}</p>
+            <div className="optimize-record__meta">
+              <span className="meta-chip">{latestRelease ? formatDateTime(latestRelease.appliedAt ?? latestRelease.requestedAt) : 'Promotion history'}</span>
+              <span className="meta-chip">{latestRelease?.status ?? 'fallback story'}</span>
+              {releaseMode ? <span className="meta-chip">{formatTokenLabel(releaseMode)}</span> : null}
+              {releaseConfidence != null ? <span className="meta-chip">{Math.round(releaseConfidence * 100)}% confidence</span> : null}
+            </div>
+          </div>
+          {latestRelease?.evidenceRefs?.length ? (
+            <div className="stack-list__item stack-list__item--body">
+              <strong>Evidence refs</strong>
+              <p>{latestRelease.evidenceRefs.join(', ')}</p>
+            </div>
+          ) : null}
+          {(releaseCreditsDelta != null || releaseDurationDelta != null || releaseSuccessDelta != null || latestRelease?.rollbackPlan) ? (
+            <div className="stack-list__item stack-list__item--body">
+              <strong>Release metadata</strong>
+              <p>
+                {releaseCreditsDelta != null ? `${formatDelta(releaseCreditsDelta)} credits` : 'No credits delta'} ·{' '}
+                {releaseDurationDelta != null ? `${formatDelta(releaseDurationDelta)}s duration` : 'No duration delta'} ·{' '}
+                {releaseSuccessDelta != null ? `${formatDelta(releaseSuccessDelta)} success` : 'No success delta'}
+              </p>
+              {latestRelease?.rollbackPlan ? <p>{latestRelease.rollbackPlan}</p> : null}
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="mini-surface">
+        <p className="eyebrow">Intervention audit</p>
+        <div className="stack-list">
+          {recentInterventions.length ? (
+            recentInterventions.map((intervention) => {
+              const phases = readConfigPatchPhases(intervention.configPatch);
+              const targetLabel =
+                intervention.targetScopeType === 'system'
+                  ? controlPlane?.system.name ?? intervention.targetScopeId
+                  : getAgentLabel(controlPlane, intervention.targetScopeId) ?? intervention.targetScopeId;
+
+              return (
+                <div key={intervention.interventionId} className="stack-list__item stack-list__item--body">
+                  <strong>{formatTokenLabel(intervention.action)}</strong>
+                  <p>{intervention.reason}</p>
+                  <div className="optimize-record__meta">
+                    <span className="meta-chip">{targetLabel}</span>
+                    <span className="meta-chip">{formatDateTime(intervention.appliedAt ?? intervention.requestedAt)}</span>
+                    <span className="meta-chip">{intervention.status ?? 'requested'}</span>
+                    {phases.length ? <span className="meta-chip">{phases.join(', ')}</span> : null}
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div className="stack-list__item stack-list__item--body">
+              <strong>No interventions recorded</strong>
+              <p>The Optimize room falls back to the saved candidate and promotion history until the control plane emits scoped interventions.</p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="mini-surface">
+        <p className="eyebrow">Saved plans</p>
+        <div className="stack-list">
+          {recentPlans.length ? (
+            recentPlans.map((plan) => (
+              <div key={plan.id} className="stack-list__item stack-list__item--body">
+                <strong>{plan.name}</strong>
+                <p>{plan.notes ?? 'No notes recorded.'}</p>
+                <div className="optimize-record__meta">
+                  <span className="meta-chip">{formatDateTime(plan.createdAt)}</span>
+                  <span className="meta-chip">{plan.executionPolicy.reviewPolicy} review</span>
+                  {plan.intentLabel ? <span className="meta-chip">{plan.intentLabel}</span> : null}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="stack-list__item stack-list__item--body">
+              <strong>No saved plans</strong>
+              <p>The fallback candidate story is empty because no saved plans were provided.</p>
+            </div>
+          )}
+        </div>
+      </section>
+
       <section className="mini-surface">
         <p className="eyebrow">Promotion history</p>
         <div className="stack-list">
-          {promotionHistory.map((promotion) => (
-            <div key={promotion.eventId} className="stack-list__item stack-list__item--body">
-              <strong>{promotion.mode}</strong>
-              <p>{promotion.summary}</p>
+          {recentPromotions.length ? (
+            recentPromotions.map((promotion) => (
+              <div key={promotion.eventId} className="stack-list__item stack-list__item--body">
+                <strong>{formatTokenLabel(promotion.mode)}</strong>
+                <p>{promotion.summary}</p>
+                <div className="optimize-record__meta">
+                  <span className="meta-chip">{formatDateTime(promotion.appliedAt)}</span>
+                  {promotion.sourceExperimentLabel ? <span className="meta-chip">{promotion.sourceExperimentLabel}</span> : null}
+                  {promotion.confidence != null ? <span className="meta-chip">{Math.round(promotion.confidence * 100)}% confidence</span> : null}
+                  {promotion.creditsDelta != null ? <span className="meta-chip">{formatDelta(promotion.creditsDelta)} credits</span> : null}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="stack-list__item stack-list__item--body">
+              <strong>No promotion history</strong>
+              <p>The release fallback story is empty because no promotion history was provided.</p>
             </div>
-          ))}
+          )}
         </div>
       </section>
-      {latestEvaluation || latestRelease ? (
-        <section className="mini-surface">
-          <p className="eyebrow">Control-plane release audit</p>
-          <div className="stack-list">
-            {latestEvaluation ? (
-              <div className="stack-list__item stack-list__item--body">
-                <strong>{latestEvaluation.verdict}</strong>
-                <p>{latestEvaluation.summary ?? 'No evaluation summary recorded.'}</p>
-              </div>
-            ) : null}
-            {latestRelease ? (
-              <div className="stack-list__item stack-list__item--body">
-                <strong>{latestRelease.decision}</strong>
-                <p>{latestRelease.summary ?? 'No release summary recorded.'}</p>
-              </div>
-            ) : null}
-          </div>
-        </section>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/optimize/OptimizePanel.tsx
+++ b/apps/web/src/features/optimize/OptimizePanel.tsx
@@ -1,5 +1,14 @@
 import type { Replay, Run, SavedPlan } from '@agent-studio/contracts';
 
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import {
+  getAgentLabel,
+  getExecutionForRun,
+  getExecutionSpans,
+  getLatestEvaluation,
+  getLatestReleaseDecision,
+  getMetricDelta,
+} from '../../app/control-plane';
 import { formatCredits, formatDelta, formatDuration } from '../../app/format';
 
 interface OptimizePanelProps {
@@ -8,6 +17,7 @@ interface OptimizePanelProps {
   candidateReplay: Replay;
   candidatePlan: SavedPlan | null;
   promotionSummary: string;
+  controlPlane?: ControlPlaneSystemState | null;
 }
 
 export function OptimizePanel({
@@ -16,9 +26,29 @@ export function OptimizePanel({
   candidateReplay,
   candidatePlan,
   promotionSummary,
+  controlPlane,
 }: OptimizePanelProps) {
-  const creditDelta = (candidateRun.actualCredits ?? 0) - (baselineRun.actualCredits ?? 0);
-  const durationDeltaSeconds = Math.round(((candidateRun.durationMs ?? 0) - (baselineRun.durationMs ?? 0)) / 1000);
+  const latestEvaluation = getLatestEvaluation(controlPlane);
+  const latestRelease = getLatestReleaseDecision(controlPlane);
+  const candidateExecution = getExecutionForRun(controlPlane, candidateRun.runId);
+  const candidateSpans = getExecutionSpans(controlPlane, candidateExecution?.executionId);
+  const creditsDelta = getMetricDelta(latestEvaluation, 'credits.actual');
+  const durationDelta = getMetricDelta(latestEvaluation, 'duration.ms');
+  const creditDelta = creditsDelta?.delta ?? ((candidateRun.actualCredits ?? 0) - (baselineRun.actualCredits ?? 0));
+  const durationDeltaMs = durationDelta?.delta ?? ((candidateRun.durationMs ?? 0) - (baselineRun.durationMs ?? 0));
+  const durationDeltaSeconds = Math.round(durationDeltaMs / 1000);
+  const releaseDecisionLabel =
+    latestRelease?.decision === 'rollback'
+      ? 'Rollback-ready'
+      : latestRelease?.decision === 'promote'
+        ? 'Promotion-ready'
+        : latestRelease?.decision
+          ? `${latestRelease.decision.charAt(0).toUpperCase()}${latestRelease.decision.slice(1)}`
+          : 'Promotion-ready';
+  const releaseLogic =
+    latestEvaluation?.summary ??
+    latestRelease?.summary ??
+    'The candidate is worth shipping because it kept the review guardrail intact while reducing spend and tightening the loop.';
 
   return (
     <div className="room-stack">
@@ -28,19 +58,21 @@ export function OptimizePanel({
             <p className="eyebrow">Release call</p>
             <h3>{candidateRun.experimentLabel}</h3>
           </div>
-          <span className="status-pill status-pill--succeeded">Promotion-ready</span>
+          <span className={`status-pill status-pill--${latestRelease?.decision === 'rollback' ? 'failed' : 'succeeded'}`}>
+            {releaseDecisionLabel}
+          </span>
         </div>
         <p className="feature-summary">
-          {promotionSummary} Optimize is the point where the public demo proves the loop closes back into a better next run.
+          {latestRelease?.summary ?? promotionSummary} Optimize is where the control plane turns a promising candidate into a real release decision.
         </p>
         <div className="metric-grid">
           <div className="metric-card">
             <span>Baseline</span>
-            <strong>{formatCredits(baselineRun.actualCredits)}</strong>
+            <strong>{formatCredits(creditsDelta?.baselineValue ?? baselineRun.actualCredits)}</strong>
           </div>
           <div className="metric-card metric-card--primary">
             <span>Candidate</span>
-            <strong>{formatCredits(candidateRun.actualCredits)}</strong>
+            <strong>{formatCredits(creditsDelta?.candidateValue ?? candidateRun.actualCredits)}</strong>
           </div>
           <div className="metric-card metric-card--success">
             <span>Credits delta</span>
@@ -53,33 +85,62 @@ export function OptimizePanel({
         </div>
         <div className="inline-callout inline-callout--success">
           <span className="eyebrow">Release logic</span>
-          <p>The candidate is worth shipping because it kept the review guardrail intact while reducing spend and tightening the loop.</p>
+          <p>{releaseLogic}</p>
         </div>
+        {candidateExecution ? (
+          <div className="inline-callout">
+            <span className="eyebrow">Candidate execution</span>
+            <p>
+              Optimize is reading execution <strong>{candidateExecution.executionId}</strong> directly with{' '}
+              <strong>{candidateSpans.length}</strong> traced spans behind this candidate.
+            </p>
+          </div>
+        ) : null}
       </section>
 
       <section className="surface">
         <div className="section-header">
           <div>
-            <p className="eyebrow">Candidate plan</p>
-            <h3>{candidatePlan?.name ?? 'No saved plan selected'}</h3>
+            <p className="eyebrow">{candidateExecution ? 'Candidate trace' : 'Candidate plan'}</p>
+            <h3>{candidateExecution ? candidateRun.experimentLabel : candidatePlan?.name ?? 'No saved plan selected'}</h3>
           </div>
           <span className="meta-chip">{candidatePlan?.executionPolicy.reviewPolicy ?? 'standard'} review</span>
         </div>
-        <p className="feature-summary">{candidatePlan?.notes ?? 'No candidate notes recorded.'}</p>
+        <p className="feature-summary">
+          {candidateExecution
+            ? 'The candidate view now reads the control-plane execution trace directly, so release evidence comes from observed runtime activity instead of only saved plan notes.'
+            : candidatePlan?.notes ?? 'No candidate notes recorded.'}
+        </p>
         <div className="timeline-list">
-          {candidateReplay.stepExecutions.map((step) => (
-            <article key={step.stepId} className={`timeline-list__item timeline-list__item--${step.status}`}>
-              <div className="timeline-list__index">{step.kind.slice(0, 1).toUpperCase()}</div>
-              <div>
-                <h4>{step.title}</h4>
-                <p>{step.summary ?? 'No step summary recorded.'}</p>
-              </div>
-              <div className="timeline-list__meta">
-                <span className="meta-chip">{step.modelTier ?? 'default'}</span>
-                <span>{formatDuration(step.durationMs)}</span>
-              </div>
-            </article>
-          ))}
+          {candidateExecution
+            ? candidateSpans.map((span) => (
+                <article key={span.spanId} className={`timeline-list__item timeline-list__item--${span.status}`}>
+                  <div className="timeline-list__index">{span.kind.slice(0, 1).toUpperCase()}</div>
+                  <div>
+                    <h4>{span.name}</h4>
+                    <p>{span.summary ?? 'No span summary recorded.'}</p>
+                  </div>
+                  <div className="timeline-list__meta">
+                    <span className={`status-pill status-pill--${span.status}`}>{span.status}</span>
+                    <span>{getAgentLabel(controlPlane, span.agentId) ?? span.kind}</span>
+                    <span>{formatDuration(span.usage?.durationMs)}</span>
+                    <span>{formatCredits(span.usage?.credits)}</span>
+                  </div>
+                </article>
+              ))
+            : candidateReplay.stepExecutions.map((step) => (
+                <article key={step.stepId} className={`timeline-list__item timeline-list__item--${step.status}`}>
+                  <div className="timeline-list__index">{step.kind.slice(0, 1).toUpperCase()}</div>
+                  <div>
+                    <h4>{step.title}</h4>
+                    <p>{step.summary ?? 'No step summary recorded.'}</p>
+                  </div>
+                  <div className="timeline-list__meta">
+                    <span className="meta-chip">{step.modelTier ?? 'default'}</span>
+                    <span>{formatDuration(step.durationMs)}</span>
+                  </div>
+                </article>
+              ))}
         </div>
       </section>
     </div>

--- a/apps/web/src/features/optimize/OptimizePanel.tsx
+++ b/apps/web/src/features/optimize/OptimizePanel.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import type { Replay, Run, SavedPlan } from '@agent-studio/contracts';
 
 import type { ControlPlaneSystemState } from '../../app/control-plane';
@@ -8,8 +10,19 @@ import {
   getLatestEvaluation,
   getLatestReleaseDecision,
   getMetricDelta,
+  summarizeAgents,
 } from '../../app/control-plane';
-import { formatCredits, formatDelta, formatDuration } from '../../app/format';
+import { formatCredits, formatDateTime, formatDelta, formatDuration, titleCaseStatus } from '../../app/format';
+
+type ComposerScope = 'system' | 'agent';
+type SystemAction = 'release.hold' | 'release.promote' | 'release.rollback';
+type AgentAction = 'directive.cheaper' | 'directive.review' | 'directive.promote';
+
+interface ActionOption<T extends string> {
+  value: T;
+  label: string;
+  summary: string;
+}
 
 interface OptimizePanelProps {
   baselineRun: Run;
@@ -18,6 +31,137 @@ interface OptimizePanelProps {
   candidatePlan: SavedPlan | null;
   promotionSummary: string;
   controlPlane?: ControlPlaneSystemState | null;
+}
+
+const SYSTEM_ACTIONS: ActionOption<SystemAction>[] = [
+  {
+    value: 'release.hold',
+    label: 'Hold release',
+    summary: 'Pause the system release while we collect another round of evidence.',
+  },
+  {
+    value: 'release.promote',
+    label: 'Promote candidate',
+    summary: 'Carry the current candidate into the live system once the release call is clear.',
+  },
+  {
+    value: 'release.rollback',
+    label: 'Prepare rollback',
+    summary: 'Keep the baseline hot and make the rollback path explicit before widening.',
+  },
+];
+
+const AGENT_ACTIONS: ActionOption<AgentAction>[] = [
+  {
+    value: 'directive.review',
+    label: 'Raise review pressure',
+    summary: 'Tighten review on one agent before widening the candidate across the system.',
+  },
+  {
+    value: 'directive.cheaper',
+    label: 'Lower spend',
+    summary: 'Push one agent toward a cheaper posture while preserving the release guardrail.',
+  },
+  {
+    value: 'directive.promote',
+    label: 'Promote behavior',
+    summary: 'Push the candidate behavior into one agent first as a bounded intervention.',
+  },
+];
+
+function formatTokenLabel(value: string) {
+  return value
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+function readMetadataNumber(metadata: unknown, key: string) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const value = (metadata as Record<string, unknown>)[key];
+
+  return typeof value === 'number' ? value : null;
+}
+
+function readConfigPatchPhases(configPatch: unknown) {
+  if (!configPatch || typeof configPatch !== 'object' || Array.isArray(configPatch)) {
+    return [];
+  }
+
+  const phases = (configPatch as Record<string, unknown>).phases;
+
+  return Array.isArray(phases) ? phases.filter((phase): phase is string => typeof phase === 'string') : [];
+}
+
+function formatMetricValue(metric: string, value?: number | null, unit?: string) {
+  if (value == null) {
+    return '—';
+  }
+
+  if (metric === 'credits.actual') {
+    return formatCredits(value);
+  }
+
+  if (metric === 'duration.ms') {
+    return formatDuration(value);
+  }
+
+  return unit ? `${value} ${unit}` : `${value}`;
+}
+
+function formatMetricDelta(metric: string, value?: number | null, unit?: string) {
+  if (value == null) {
+    return '—';
+  }
+
+  if (metric === 'credits.actual') {
+    return `${formatDelta(value)} cr`;
+  }
+
+  if (metric === 'duration.ms') {
+    return `${formatDelta(Math.round(value / 1000))}s`;
+  }
+
+  return unit ? `${formatDelta(value)} ${unit}` : formatDelta(value);
+}
+
+function buildSuggestedReason(args: {
+  scope: ComposerScope;
+  action: AgentAction | SystemAction;
+  targetLabel: string;
+  targetEvidence: string | null;
+  evaluationSummary: string | null;
+  releaseSummary: string | null;
+  promotionSummary: string;
+}) {
+  const supportingEvidence =
+    args.targetEvidence ?? args.evaluationSummary ?? args.releaseSummary ?? args.promotionSummary;
+
+  if (args.scope === 'system') {
+    if (args.action === 'release.promote') {
+      return args.releaseSummary ?? args.evaluationSummary ?? args.promotionSummary;
+    }
+
+    if (args.action === 'release.rollback') {
+      return `Keep ${args.targetLabel} on the baseline until the release evidence is cleaner. ${supportingEvidence}`;
+    }
+
+    return `Hold the release for ${args.targetLabel} until another evaluation confirms the candidate is safe to widen. ${supportingEvidence}`;
+  }
+
+  if (args.action === 'directive.cheaper') {
+    return `${args.targetLabel} is the cleanest place to trim spend before touching the rest of the system. ${supportingEvidence}`;
+  }
+
+  if (args.action === 'directive.promote') {
+    return `${args.targetLabel} can adopt the candidate behavior next because the release evidence is already favorable. ${supportingEvidence}`;
+  }
+
+  return `Raise review pressure on ${args.targetLabel} before widening the release. ${supportingEvidence}`;
 }
 
 export function OptimizePanel({
@@ -30,8 +174,10 @@ export function OptimizePanel({
 }: OptimizePanelProps) {
   const latestEvaluation = getLatestEvaluation(controlPlane);
   const latestRelease = getLatestReleaseDecision(controlPlane);
+  const latestIntervention = controlPlane?.interventions[0] ?? null;
   const candidateExecution = getExecutionForRun(controlPlane, candidateRun.runId);
   const candidateSpans = getExecutionSpans(controlPlane, candidateExecution?.executionId);
+  const agentSummaries = summarizeAgents(controlPlane);
   const creditsDelta = getMetricDelta(latestEvaluation, 'credits.actual');
   const durationDelta = getMetricDelta(latestEvaluation, 'duration.ms');
   const creditDelta = creditsDelta?.delta ?? ((candidateRun.actualCredits ?? 0) - (baselineRun.actualCredits ?? 0));
@@ -43,19 +189,89 @@ export function OptimizePanel({
       : latestRelease?.decision === 'promote'
         ? 'Promotion-ready'
         : latestRelease?.decision
-          ? `${latestRelease.decision.charAt(0).toUpperCase()}${latestRelease.decision.slice(1)}`
+          ? formatTokenLabel(latestRelease.decision)
           : 'Promotion-ready';
   const releaseLogic =
     latestEvaluation?.summary ??
     latestRelease?.summary ??
     'The candidate is worth shipping because it kept the review guardrail intact while reducing spend and tightening the loop.';
+  const releaseConfidence = readMetadataNumber(latestRelease?.metadata, 'confidence');
+  const releaseCreditsDelta = readMetadataNumber(latestRelease?.metadata, 'creditsDelta');
+  const releaseDurationDelta = readMetadataNumber(latestRelease?.metadata, 'durationDelta');
+  const recommendedAgentId =
+    (latestIntervention?.targetScopeType === 'agent' ? latestIntervention.targetScopeId : null) ??
+    candidateSpans.find((span) => span.agentId)?.agentId ??
+    agentSummaries[0]?.agent.agentId ??
+    controlPlane?.agents[0]?.agentId ??
+    '';
+
+  const [composerScope, setComposerScope] = useState<ComposerScope>('system');
+  const [systemAction, setSystemAction] = useState<SystemAction>('release.hold');
+  const [agentAction, setAgentAction] = useState<AgentAction>('directive.review');
+  const [selectedAgentId, setSelectedAgentId] = useState('');
+  const [reasonDraft, setReasonDraft] = useState('');
+
+  useEffect(() => {
+    const hasSelectedAgent = selectedAgentId
+      ? agentSummaries.some((summary) => summary.agent.agentId === selectedAgentId)
+      : false;
+
+    if (!hasSelectedAgent && recommendedAgentId) {
+      setSelectedAgentId(recommendedAgentId);
+    }
+  }, [agentSummaries, recommendedAgentId, selectedAgentId]);
+
+  const selectedAgentSummary =
+    agentSummaries.find((summary) => summary.agent.agentId === selectedAgentId) ?? agentSummaries[0] ?? null;
+  const selectedAgentTrace = candidateSpans.find((span) => span.agentId === selectedAgentSummary?.agent.agentId) ?? null;
+  const activeAction = composerScope === 'system' ? systemAction : agentAction;
+  const activeActionOption =
+    composerScope === 'system'
+      ? SYSTEM_ACTIONS.find((option) => option.value === systemAction)
+      : AGENT_ACTIONS.find((option) => option.value === agentAction);
+  const targetLabel = composerScope === 'system' ? controlPlane?.system.name ?? candidateReplay.workflow.name : selectedAgentSummary?.agent.label ?? 'Selected agent';
+  const targetScopeId =
+    composerScope === 'system' ? controlPlane?.system.systemId ?? candidateReplay.workflow.workflowId : selectedAgentSummary?.agent.agentId ?? selectedAgentId;
+  const targetEvidence =
+    composerScope === 'system'
+      ? latestRelease?.summary ?? latestEvaluation?.summary ?? null
+      : selectedAgentSummary?.latestIntervention?.reason ??
+        selectedAgentSummary?.latestSpan?.summary ??
+        selectedAgentTrace?.summary ??
+        null;
+  const composerReason =
+    reasonDraft.trim() ||
+    buildSuggestedReason({
+      scope: composerScope,
+      action: activeAction,
+      targetLabel,
+      targetEvidence,
+      evaluationSummary: latestEvaluation?.summary ?? null,
+      releaseSummary: latestRelease?.summary ?? null,
+      promotionSummary,
+    });
+  const draftStatus =
+    composerScope === 'system'
+      ? systemAction === 'release.rollback'
+        ? 'failed'
+        : systemAction === 'release.promote'
+          ? 'succeeded'
+          : 'active'
+      : agentAction === 'directive.review'
+        ? 'active'
+        : agentAction === 'directive.promote'
+          ? 'succeeded'
+          : 'active';
+  const draftEvidenceRef =
+    latestEvaluation?.evaluationId ?? latestRelease?.releaseId ?? candidateExecution?.executionId ?? candidateRun.runId;
+  const latestInterventionPhases = readConfigPatchPhases(latestIntervention?.configPatch);
 
   return (
     <div className="room-stack">
       <section className="surface">
         <div className="section-header">
           <div>
-            <p className="eyebrow">Release call</p>
+            <p className="eyebrow">Release workbench</p>
             <h3>{candidateRun.experimentLabel}</h3>
           </div>
           <span className={`status-pill status-pill--${latestRelease?.decision === 'rollback' ? 'failed' : 'succeeded'}`}>
@@ -63,7 +279,7 @@ export function OptimizePanel({
           </span>
         </div>
         <p className="feature-summary">
-          {latestRelease?.summary ?? promotionSummary} Optimize is where the control plane turns a promising candidate into a real release decision.
+          {latestRelease?.summary ?? promotionSummary} Optimize now stays scoped to interventions and release work that the control plane can already explain.
         </p>
         <div className="metric-grid">
           <div className="metric-card">
@@ -83,6 +299,27 @@ export function OptimizePanel({
             <strong>{formatDelta(durationDeltaSeconds)}s</strong>
           </div>
         </div>
+        <div className="signal-band">
+          <article className="signal-band__card">
+            <span className="eyebrow">Latest evaluation</span>
+            <strong>{latestEvaluation ? titleCaseStatus(latestEvaluation.verdict) : 'Candidate fallback'}</strong>
+            <p>{latestEvaluation?.summary ?? candidatePlan?.notes ?? 'No evaluation is recorded yet, so the saved candidate story stays in front.'}</p>
+          </article>
+          <article className="signal-band__card signal-band__card--accent">
+            <span className="eyebrow">Latest release</span>
+            <strong>{latestRelease ? formatTokenLabel(latestRelease.decision) : 'Promotion story'}</strong>
+            <p>{latestRelease?.summary ?? promotionSummary}</p>
+          </article>
+          <article className="signal-band__card signal-band__card--directive">
+            <span className="eyebrow">Scoped target</span>
+            <strong>{composerScope === 'system' ? targetLabel : selectedAgentSummary?.agent.label ?? 'Pick an agent'}</strong>
+            <p>
+              {composerScope === 'system'
+                ? 'System-level release action staged from the latest evaluation and release call.'
+                : targetEvidence ?? 'Use the agent selector to scope the next intervention.'}
+            </p>
+          </article>
+        </div>
         <div className="inline-callout inline-callout--success">
           <span className="eyebrow">Release logic</span>
           <p>{releaseLogic}</p>
@@ -101,14 +338,163 @@ export function OptimizePanel({
       <section className="surface">
         <div className="section-header">
           <div>
-            <p className="eyebrow">{candidateExecution ? 'Candidate trace' : 'Candidate plan'}</p>
+            <p className="eyebrow">Scoped intervention</p>
+            <h3>Compose from current control-plane evidence</h3>
+          </div>
+          <span className="meta-chip">{composerScope === 'system' ? 'system target' : 'agent target'}</span>
+        </div>
+        <p className="feature-summary">
+          This composer stays intentionally bounded: it lets you shape the next intervention around the current system or one agent without inventing a second release workflow.
+        </p>
+        <div className="optimize-workbench">
+          <div className="mini-surface">
+            <div className="optimize-composer__grid">
+              <label className="select-field">
+                <span>Target scope</span>
+                <select value={composerScope} onChange={(event) => setComposerScope(event.target.value as ComposerScope)}>
+                  <option value="system">System</option>
+                  <option value="agent">Agent</option>
+                </select>
+              </label>
+              {composerScope === 'agent' ? (
+                <label className="select-field">
+                  <span>Agent target</span>
+                  <select value={selectedAgentSummary?.agent.agentId ?? ''} onChange={(event) => setSelectedAgentId(event.target.value)}>
+                    {agentSummaries.map((summary) => (
+                      <option key={summary.agent.agentId} value={summary.agent.agentId}>
+                        {summary.agent.label}
+                      </option>
+                    ))}
+                  </select>
+                  <small>
+                    {selectedAgentSummary
+                      ? `${selectedAgentSummary.failedSpanCount} failed spans, ${selectedAgentSummary.activeInterventionCount} active directives`
+                      : 'No agent pressure data is available yet.'}
+                  </small>
+                </label>
+              ) : (
+                <div className="mini-note">
+                  <span className="eyebrow">System target</span>
+                  <strong>{controlPlane?.system.name ?? candidateReplay.workflow.name}</strong>
+                  <p className="muted">
+                    Use this when the next move is a release call or a system-wide guardrail, not a single-agent correction.
+                  </p>
+                </div>
+              )}
+            </div>
+            <label className="select-field">
+              <span>{composerScope === 'system' ? 'Release action' : 'Agent action'}</span>
+              <select
+                value={activeAction}
+                onChange={(event) =>
+                  composerScope === 'system'
+                    ? setSystemAction(event.target.value as SystemAction)
+                    : setAgentAction(event.target.value as AgentAction)
+                }
+              >
+                {(composerScope === 'system' ? SYSTEM_ACTIONS : AGENT_ACTIONS).map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <small>{activeActionOption?.summary}</small>
+            </label>
+            <label className="text-field">
+              <span>Intervention reason</span>
+              <textarea
+                value={reasonDraft}
+                onChange={(event) => setReasonDraft(event.target.value)}
+                placeholder="Use the live evidence on the right or keep the suggested rationale."
+              />
+            </label>
+            <div className={`inline-callout inline-callout--${draftStatus === 'failed' ? 'warning' : 'success'}`}>
+              <span className="eyebrow">Draft intervention</span>
+              <p>{composerReason}</p>
+              <div className="optimize-composer__meta">
+                <span className={`status-pill status-pill--${draftStatus}`}>{formatTokenLabel(activeAction)}</span>
+                <span className="meta-chip">{composerScope}</span>
+                <span className="meta-chip">{targetScopeId}</span>
+                <span className="meta-chip">{draftEvidenceRef}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="mini-surface">
+            <p className="eyebrow">Latest evidence</p>
+            <div className="stack-list">
+              <div className="stack-list__item stack-list__item--body">
+                <strong>{latestEvaluation ? `${titleCaseStatus(latestEvaluation.verdict)} evaluation` : 'Candidate fallback story'}</strong>
+                <p>{latestEvaluation?.summary ?? candidatePlan?.notes ?? promotionSummary}</p>
+                <div className="optimize-record__meta">
+                  <span className="meta-chip">{latestEvaluation ? formatDateTime(latestEvaluation.createdAt) : 'Saved candidate'}</span>
+                  <span className="meta-chip">
+                    {latestEvaluation ? `${latestEvaluation.baselineRefs.length} baseline ref${latestEvaluation.baselineRefs.length === 1 ? '' : 's'}` : baselineRun.runId}
+                  </span>
+                  <span className="meta-chip">
+                    {latestEvaluation ? `${latestEvaluation.candidateRefs.length} candidate ref${latestEvaluation.candidateRefs.length === 1 ? '' : 's'}` : candidateRun.runId}
+                  </span>
+                </div>
+              </div>
+              {latestEvaluation?.metricDeltas?.map((metric) => (
+                <div key={metric.metric} className="stack-list__item stack-list__item--body">
+                  <strong>{formatTokenLabel(metric.metric)}</strong>
+                  <p>
+                    Baseline {formatMetricValue(metric.metric, metric.baselineValue, metric.unit)} · Candidate{' '}
+                    {formatMetricValue(metric.metric, metric.candidateValue, metric.unit)} · Delta{' '}
+                    {formatMetricDelta(metric.metric, metric.delta, metric.unit)}
+                  </p>
+                </div>
+              ))}
+              <div className="stack-list__item stack-list__item--body">
+                <strong>{latestRelease ? `${formatTokenLabel(latestRelease.decision)} release` : 'Promotion fallback'}</strong>
+                <p>{latestRelease?.summary ?? promotionSummary}</p>
+                <div className="optimize-record__meta">
+                  <span className="meta-chip">{latestRelease ? formatDateTime(latestRelease.appliedAt ?? latestRelease.requestedAt) : 'Saved release story'}</span>
+                  <span className="meta-chip">{latestRelease?.status ?? 'candidate summary'}</span>
+                  {releaseConfidence != null ? <span className="meta-chip">{Math.round(releaseConfidence * 100)}% confidence</span> : null}
+                </div>
+              </div>
+              {latestIntervention ? (
+                <div className="stack-list__item stack-list__item--body">
+                  <strong>{formatTokenLabel(latestIntervention.action)}</strong>
+                  <p>{latestIntervention.reason}</p>
+                  <div className="optimize-record__meta">
+                    <span className="meta-chip">
+                      {latestIntervention.targetScopeType === 'system'
+                        ? controlPlane?.system.name ?? latestIntervention.targetScopeId
+                        : getAgentLabel(controlPlane, latestIntervention.targetScopeId) ?? latestIntervention.targetScopeId}
+                    </span>
+                    <span className="meta-chip">{formatDateTime(latestIntervention.appliedAt ?? latestIntervention.requestedAt)}</span>
+                    {latestInterventionPhases.length ? <span className="meta-chip">{latestInterventionPhases.join(', ')}</span> : null}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+            {(releaseCreditsDelta != null || releaseDurationDelta != null) ? (
+              <div className="inline-callout">
+                <span className="eyebrow">Release deltas</span>
+                <p>
+                  {releaseCreditsDelta != null ? `${formatDelta(releaseCreditsDelta)} credits` : 'No credits delta'} ·{' '}
+                  {releaseDurationDelta != null ? `${formatDelta(releaseDurationDelta)}s duration` : 'No duration delta'}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="surface">
+        <div className="section-header">
+          <div>
+            <p className="eyebrow">{candidateExecution ? 'Candidate trace' : 'Candidate fallback'}</p>
             <h3>{candidateExecution ? candidateRun.experimentLabel : candidatePlan?.name ?? 'No saved plan selected'}</h3>
           </div>
           <span className="meta-chip">{candidatePlan?.executionPolicy.reviewPolicy ?? 'standard'} review</span>
         </div>
         <p className="feature-summary">
           {candidateExecution
-            ? 'The candidate view now reads the control-plane execution trace directly, so release evidence comes from observed runtime activity instead of only saved plan notes.'
+            ? 'The candidate trace remains the fallback release story when you need to inspect the exact runtime path behind the current evidence.'
             : candidatePlan?.notes ?? 'No candidate notes recorded.'}
         </p>
         <div className="timeline-list">

--- a/apps/web/src/features/replay/ReplayAdvancedPanel.tsx
+++ b/apps/web/src/features/replay/ReplayAdvancedPanel.tsx
@@ -2,6 +2,7 @@ import type { Replay } from '@agent-studio/contracts';
 
 import type { ControlPlaneSystemState } from '../../app/control-plane';
 import { getExecutionForRun, getExecutionSpans } from '../../app/control-plane';
+import { formatSignedCreditsDelta, formatSignedDurationDelta, buildReplaySpanTree } from './replay-model';
 
 interface ReplayAdvancedPanelProps {
   replay: Replay;
@@ -13,24 +14,41 @@ export function ReplayAdvancedPanel({ replay, controlPlane }: ReplayAdvancedPane
   const comparison = replay.operationalContext?.lastHealthyComparison;
   const execution = getExecutionForRun(controlPlane, replay.run.runId);
   const spans = getExecutionSpans(controlPlane, execution?.executionId);
+  const spanTree = spans.length ? buildReplaySpanTree(spans) : null;
 
   return (
     <div className="advanced-grid">
       <section className="mini-surface">
         <p className="eyebrow">Evidence trail</p>
-        <div className="stack-list">
-          {evidence.map((item) => (
-            <div key={item.evidenceId} className="stack-list__item stack-list__item--body">
-              <strong>{item.title}</strong>
-              <p>{item.body}</p>
-            </div>
-          ))}
-        </div>
+        {evidence.length ? (
+          <div className="stack-list">
+            {evidence.map((item) => (
+              <div key={item.evidenceId} className="stack-list__item stack-list__item--body">
+                <strong>{item.title}</strong>
+                <p>{item.body}</p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="muted">No recommendation evidence recorded.</p>
+        )}
       </section>
       <section className="mini-surface">
         <p className="eyebrow">Healthy comparison</p>
         {comparison ? (
           <div className="stack-list">
+            <div className="stack-list__item stack-list__item--body">
+              <strong>{comparison.label}</strong>
+              <p>{comparison.summary}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Credit delta</strong>
+              <p>{formatSignedCreditsDelta(comparison.creditsDelta)}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Duration delta</strong>
+              <p>{formatSignedDurationDelta(comparison.durationDelta)}</p>
+            </div>
             {comparison.changedSignals.map((signal) => (
               <div key={signal} className="stack-list__item">
                 <strong>{signal}</strong>
@@ -43,7 +61,7 @@ export function ReplayAdvancedPanel({ replay, controlPlane }: ReplayAdvancedPane
       </section>
       {execution ? (
         <section className="mini-surface">
-          <p className="eyebrow">Trace summary</p>
+          <p className="eyebrow">Trace breakdown</p>
           <div className="stack-list">
             <div className="stack-list__item">
               <strong>Execution</strong>
@@ -56,6 +74,22 @@ export function ReplayAdvancedPanel({ replay, controlPlane }: ReplayAdvancedPane
             <div className="stack-list__item">
               <strong>Recorded spans</strong>
               <p>{spans.length}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Root spans</strong>
+              <p>{spanTree?.stats.rootCount ?? 0}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Nested handoffs</strong>
+              <p>{spanTree?.stats.nestedSpanCount ?? 0}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Deepest chain</strong>
+              <p>{spanTree?.stats.maxDepth ?? 0} levels</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Failed spans</strong>
+              <p>{spanTree?.stats.failedCount ?? 0}</p>
             </div>
             <div className="stack-list__item">
               <strong>Interventions in system</strong>

--- a/apps/web/src/features/replay/ReplayAdvancedPanel.tsx
+++ b/apps/web/src/features/replay/ReplayAdvancedPanel.tsx
@@ -1,12 +1,18 @@
 import type { Replay } from '@agent-studio/contracts';
 
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { getExecutionForRun, getExecutionSpans } from '../../app/control-plane';
+
 interface ReplayAdvancedPanelProps {
   replay: Replay;
+  controlPlane?: ControlPlaneSystemState | null;
 }
 
-export function ReplayAdvancedPanel({ replay }: ReplayAdvancedPanelProps) {
+export function ReplayAdvancedPanel({ replay, controlPlane }: ReplayAdvancedPanelProps) {
   const evidence = replay.operationalContext?.recommendationEvidence ?? [];
   const comparison = replay.operationalContext?.lastHealthyComparison;
+  const execution = getExecutionForRun(controlPlane, replay.run.runId);
+  const spans = getExecutionSpans(controlPlane, execution?.executionId);
 
   return (
     <div className="advanced-grid">
@@ -35,6 +41,29 @@ export function ReplayAdvancedPanel({ replay }: ReplayAdvancedPanelProps) {
           <p className="muted">No healthy comparison recorded.</p>
         )}
       </section>
+      {execution ? (
+        <section className="mini-surface">
+          <p className="eyebrow">Trace summary</p>
+          <div className="stack-list">
+            <div className="stack-list__item">
+              <strong>Execution</strong>
+              <p>{execution.executionId}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Trace</strong>
+              <p>{execution.traceId}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Recorded spans</strong>
+              <p>{spans.length}</p>
+            </div>
+            <div className="stack-list__item">
+              <strong>Interventions in system</strong>
+              <p>{controlPlane?.interventions.length ?? 0}</p>
+            </div>
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/replay/ReplayPanel.test.tsx
+++ b/apps/web/src/features/replay/ReplayPanel.test.tsx
@@ -1,0 +1,285 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { Replay, Run } from '@agent-studio/contracts';
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { ReplayAdvancedPanel } from './ReplayAdvancedPanel';
+import { ReplayPanel } from './ReplayPanel';
+
+const baselineRun: Run = {
+  runId: 'run_base',
+  workflowId: 'workflow_ops_brief',
+  status: 'succeeded',
+  startedAt: '2026-04-17T13:00:00.000Z',
+  finishedAt: '2026-04-17T13:09:20.000Z',
+  actualCredits: 32,
+  durationMs: 560000,
+  experimentLabel: 'Baseline control',
+};
+
+const replay: Replay = {
+  workflow: {
+    workspaceId: 'workspace_demo',
+    workflowId: 'workflow_ops_brief',
+    name: 'Weekly Operations Brief',
+    status: 'active',
+    steps: [
+      {
+        stepId: 'capture-intake',
+        kind: 'capture',
+        title: 'Capture intake',
+        objective: 'Capture context',
+        assignedRole: 'coordinator',
+      },
+      {
+        stepId: 'collect-evidence',
+        kind: 'search',
+        title: 'Collect evidence',
+        objective: 'Find evidence',
+        assignedRole: 'researcher',
+        dependsOnStepIds: ['capture-intake'],
+      },
+      {
+        stepId: 'review-guardrail',
+        kind: 'note',
+        title: 'Review guardrail',
+        objective: 'Check policy',
+        assignedRole: 'reviewer',
+        dependsOnStepIds: ['collect-evidence'],
+      },
+    ],
+  },
+  run: {
+    runId: 'run_replay',
+    workflowId: 'workflow_ops_brief',
+    status: 'failed',
+    startedAt: '2026-04-18T13:00:00.000Z',
+    finishedAt: '2026-04-18T13:10:40.000Z',
+    actualCredits: 35,
+    durationMs: 640000,
+    experimentLabel: 'Lean review failure',
+  },
+  stepExecutions: [
+    {
+      stepId: 'capture-intake',
+      kind: 'capture',
+      title: 'Capture intake',
+      assignedRole: 'coordinator',
+      status: 'succeeded',
+      actualCredits: 4,
+      summary: 'Captured the operating brief.',
+    },
+    {
+      stepId: 'collect-evidence',
+      kind: 'search',
+      title: 'Collect evidence',
+      assignedRole: 'researcher',
+      status: 'succeeded',
+      actualCredits: 12,
+      summary: 'Evidence collection widened more than expected.',
+    },
+    {
+      stepId: 'review-guardrail',
+      kind: 'note',
+      title: 'Review guardrail',
+      assignedRole: 'reviewer',
+      status: 'failed',
+      actualCredits: 19,
+      summary: 'The review gate failed on unsupported claims.',
+    },
+  ],
+  operationalContext: {
+    workflowId: 'workflow_ops_brief',
+    generatedAt: '2026-04-18T13:11:00.000Z',
+    similarRuns: [],
+    lastHealthyComparison: {
+      runId: 'run_base',
+      label: 'Baseline control',
+      startedAt: '2026-04-17T13:00:00.000Z',
+      finishedAt: '2026-04-17T13:09:20.000Z',
+      creditsDelta: 3,
+      durationDelta: 80000,
+      changedSignals: [
+        'Lean review skipped a citation verification pass',
+        'Source fan-out widened and produced duplicate notes',
+      ],
+      summary: 'The degraded replay traded away the review gate and paid for it with rework and a failed publish.',
+    },
+    recommendationEvidence: [
+      {
+        evidenceId: 'evidence_1',
+        title: 'Guardrail failed last',
+        body: 'The failure happened inside the review gate, not during evidence collection.',
+        sourceLabel: 'Failed replay',
+      },
+    ],
+  },
+};
+
+const controlPlaneFixture: ControlPlaneSystemState = {
+  system: {
+    systemId: 'system_workflow_ops_brief',
+    workspaceId: 'workspace_demo',
+    name: 'Weekly Operations Brief',
+    runtimeIds: ['runtime_demo_seeded'],
+    metadata: {
+      workflowId: 'workflow_ops_brief',
+    },
+  },
+  agents: [
+    {
+      agentId: 'agent_coord',
+      systemId: 'system_workflow_ops_brief',
+      label: 'Coordinator',
+      kind: 'assistant',
+      role: 'coordinator',
+      runtimeId: 'runtime_demo_seeded',
+      status: 'active',
+    },
+    {
+      agentId: 'agent_research',
+      systemId: 'system_workflow_ops_brief',
+      label: 'Researcher',
+      kind: 'assistant',
+      role: 'researcher',
+      runtimeId: 'runtime_demo_seeded',
+      status: 'active',
+    },
+    {
+      agentId: 'agent_review',
+      systemId: 'system_workflow_ops_brief',
+      label: 'Reviewer',
+      kind: 'assistant',
+      role: 'reviewer',
+      runtimeId: 'runtime_demo_seeded',
+      status: 'active',
+    },
+  ],
+  topology: null,
+  executions: [
+    {
+      executionId: 'exec_replay',
+      traceId: 'trace_replay',
+      systemId: 'system_workflow_ops_brief',
+      runtimeId: 'runtime_demo_seeded',
+      workflowId: 'workflow_ops_brief',
+      runId: 'run_replay',
+      status: 'failed',
+      startedAt: '2026-04-18T13:00:00.000Z',
+      finishedAt: '2026-04-18T13:10:40.000Z',
+    },
+  ],
+  executionSpans: {
+    exec_replay: [
+      {
+        spanId: 'span_capture',
+        traceId: 'trace_replay',
+        executionId: 'exec_replay',
+        agentId: 'agent_coord',
+        name: 'Capture intake',
+        kind: 'capture',
+        status: 'succeeded',
+        startedAt: '2026-04-18T13:00:00.000Z',
+        finishedAt: '2026-04-18T13:01:18.000Z',
+        summary: 'Captured the operating brief.',
+        usage: {
+          credits: 4,
+          durationMs: 78000,
+        },
+      },
+      {
+        spanId: 'span_collect',
+        traceId: 'trace_replay',
+        executionId: 'exec_replay',
+        parentSpanId: 'span_capture',
+        agentId: 'agent_research',
+        name: 'Collect evidence',
+        kind: 'search',
+        status: 'succeeded',
+        startedAt: '2026-04-18T13:01:20.000Z',
+        finishedAt: '2026-04-18T13:04:40.000Z',
+        summary: 'Evidence collection widened more than expected.',
+        usage: {
+          credits: 12,
+          durationMs: 200000,
+        },
+      },
+      {
+        spanId: 'span_review',
+        traceId: 'trace_replay',
+        executionId: 'exec_replay',
+        parentSpanId: 'span_collect',
+        agentId: 'agent_review',
+        name: 'Review guardrail',
+        kind: 'note',
+        status: 'failed',
+        startedAt: '2026-04-18T13:04:42.000Z',
+        finishedAt: '2026-04-18T13:10:40.000Z',
+        summary: 'The review gate failed on unsupported claims.',
+        usage: {
+          credits: 19,
+          durationMs: 358000,
+        },
+      },
+    ],
+  },
+  executionMetrics: {
+    exec_replay: [
+      {
+        sampleId: 'metric_credits',
+        metric: 'credits.actual',
+        unit: 'credits',
+        value: 35,
+        ts: '2026-04-18T13:10:40.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_replay',
+      },
+      {
+        sampleId: 'metric_duration',
+        metric: 'duration.ms',
+        unit: 'ms',
+        value: 640000,
+        ts: '2026-04-18T13:10:40.000Z',
+        scopeType: 'execution',
+        scopeId: 'exec_replay',
+      },
+    ],
+  },
+  interventions: [],
+  evaluations: [],
+  releases: [],
+};
+
+describe('ReplayPanel', () => {
+  it('renders the baseline compare and execution tree from control-plane spans', () => {
+    const { container } = render(<ReplayPanel replay={replay} baselineRun={baselineRun} controlPlane={controlPlaneFixture} />);
+
+    expect(screen.getByRole('heading', { name: 'Execution tree' })).toBeInTheDocument();
+    expect(screen.getByText('Baseline control')).toBeInTheDocument();
+    expect(screen.getByText('Spend +3 cr / Time +1m 20s')).toBeInTheDocument();
+    expect(screen.getByText('1 root spans')).toBeInTheDocument();
+    expect(screen.getByText('2 nested handoffs')).toBeInTheDocument();
+    expect(container.querySelector('.replay-tree__children .replay-tree__children')).not.toBeNull();
+    expect(screen.getAllByText('Nested handoff')).toHaveLength(2);
+  });
+
+  it('falls back to the legacy step replay when no execution trace is available', () => {
+    render(<ReplayPanel replay={replay} baselineRun={baselineRun} controlPlane={null} />);
+
+    expect(screen.getByRole('heading', { name: 'Step-by-step replay' })).toBeInTheDocument();
+    expect(screen.getByText('3 recorded steps')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Execution tree' })).not.toBeInTheDocument();
+  });
+});
+
+describe('ReplayAdvancedPanel', () => {
+  it('shows comparison deltas and trace breakdown details', () => {
+    render(<ReplayAdvancedPanel replay={replay} controlPlane={controlPlaneFixture} />);
+
+    expect(screen.getByText('Credit delta')).toBeInTheDocument();
+    expect(screen.getByText('+3 cr')).toBeInTheDocument();
+    expect(screen.getByText('Root spans')).toBeInTheDocument();
+    expect(screen.getByText('Deepest chain')).toBeInTheDocument();
+    expect(screen.getByText('3 levels')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/replay/ReplayPanel.tsx
+++ b/apps/web/src/features/replay/ReplayPanel.tsx
@@ -1,15 +1,34 @@
 import type { Replay, Run } from '@agent-studio/contracts';
 
-import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { getAgentLabel, getExecutionForRun, getExecutionMetrics, getExecutionSpans } from '../../app/control-plane';
+import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface ReplayPanelProps {
   replay: Replay;
   baselineRun: Run;
+  controlPlane?: ControlPlaneSystemState | null;
 }
 
-export function ReplayPanel({ replay, baselineRun }: ReplayPanelProps) {
+export function ReplayPanel({ replay, baselineRun, controlPlane }: ReplayPanelProps) {
   const comparison = replay.operationalContext?.lastHealthyComparison;
   const failedStep = replay.stepExecutions.find((step) => step.status === 'failed');
+  const execution = getExecutionForRun(controlPlane, replay.run.runId);
+  const spans = getExecutionSpans(controlPlane, execution?.executionId);
+  const executionMetrics = getExecutionMetrics(controlPlane, execution?.executionId);
+  const failedSpan = spans.find((span) => span.status === 'failed') ?? null;
+  const observedAgentCount = new Set(spans.map((span) => span.agentId).filter(Boolean)).size;
+  const creditsMetric = executionMetrics.find((metric) => metric.metric === 'credits.actual');
+  const durationMetric = executionMetrics.find((metric) => metric.metric === 'duration.ms');
+  const replayHeadline =
+    failedSpan?.summary ??
+    failedStep?.summary ??
+    failedSpan?.name ??
+    failedStep?.title ??
+    'The replay makes the decision point obvious.';
+  const replayBody = execution
+    ? `Replay is now reading the control-plane trace directly: ${spans.length} spans across ${observedAgentCount || 1} tracked agents in execution ${execution.executionId}.`
+    : 'Replay is there to show the exact break, not to bury it in generic analytics.';
 
   return (
     <div className="room-stack">
@@ -22,21 +41,20 @@ export function ReplayPanel({ replay, baselineRun }: ReplayPanelProps) {
           <span className={`status-pill status-pill--${replay.run.status}`}>{titleCaseStatus(replay.run.status)}</span>
         </div>
         <p className="feature-summary">
-          {failedStep?.summary ?? 'The replay makes the decision point obvious.'} Replay is there to show the exact break,
-          not to bury it in generic analytics.
+          {replayHeadline} {replayBody}
         </p>
         <div className="metric-grid">
           <div className="metric-card metric-card--warning">
             <span>Failed at</span>
-            <strong>{failedStep?.title ?? 'No failed step'}</strong>
+            <strong>{failedSpan?.name ?? failedStep?.title ?? 'No failed step'}</strong>
           </div>
           <div className="metric-card">
             <span>Actual spend</span>
-            <strong>{formatCredits(replay.run.actualCredits)}</strong>
+            <strong>{formatCredits(creditsMetric?.value ?? replay.run.actualCredits)}</strong>
           </div>
           <div className="metric-card">
             <span>Duration</span>
-            <strong>{formatDuration(replay.run.durationMs)}</strong>
+            <strong>{formatDuration(durationMetric?.value ?? replay.run.durationMs)}</strong>
           </div>
           <div className="metric-card metric-card--primary">
             <span>Healthy control</span>
@@ -49,31 +67,60 @@ export function ReplayPanel({ replay, baselineRun }: ReplayPanelProps) {
             <p>{comparison.summary}</p>
           </div>
         ) : null}
+        {execution ? (
+          <div className="inline-callout">
+            <span className="eyebrow">Trace context</span>
+            <p>
+              Trace <strong>{execution.traceId}</strong> started {formatDateTime(execution.startedAt)} and is tied to{' '}
+              <strong>{controlPlane?.system.name ?? 'this system'}</strong>. This replay is using execution-native spans instead
+              of only flattened step summaries.
+            </p>
+          </div>
+        ) : null}
       </section>
 
       <section className="surface">
         <div className="section-header">
           <div>
             <p className="eyebrow">Run timeline</p>
-            <h3>Step-by-step replay</h3>
+            <h3>{execution ? 'Execution and span replay' : 'Step-by-step replay'}</h3>
           </div>
-          <span className="meta-chip">{replay.stepExecutions.length} recorded steps</span>
+          <span className="meta-chip">{execution ? `${spans.length} recorded spans` : `${replay.stepExecutions.length} recorded steps`}</span>
         </div>
         <div className="timeline-list">
-          {replay.stepExecutions.map((step) => (
-            <article key={step.stepId} className={`timeline-list__item timeline-list__item--${step.status}`}>
-              <div className={`timeline-list__index timeline-list__index--${step.status}`} />
-              <div>
-                <h4>{step.title}</h4>
-                <p>{step.summary ?? step.error ?? 'No step summary recorded.'}</p>
-              </div>
-              <div className="timeline-list__meta">
-                <span className={`status-pill status-pill--${step.status}`}>{titleCaseStatus(step.status)}</span>
-                <span>{step.assignedRole}</span>
-                <span>{formatCredits(step.actualCredits)}</span>
-              </div>
-            </article>
-          ))}
+          {execution
+            ? spans.map((span) => (
+                <article key={span.spanId} className={`timeline-list__item timeline-list__item--${span.status}`}>
+                  <div className={`timeline-list__index timeline-list__index--${span.status}`} />
+                  <div>
+                    <h4>{span.name}</h4>
+                    <p>
+                      {span.summary ?? 'No span summary recorded.'}
+                      {span.parentSpanId ? ` Linked from ${span.parentSpanId}.` : ''}
+                    </p>
+                  </div>
+                  <div className="timeline-list__meta">
+                    <span className={`status-pill status-pill--${span.status}`}>{titleCaseStatus(span.status)}</span>
+                    <span>{getAgentLabel(controlPlane, span.agentId) ?? span.kind}</span>
+                    <span>{formatCredits(span.usage?.credits)}</span>
+                    <span>{formatDuration(span.usage?.durationMs)}</span>
+                  </div>
+                </article>
+              ))
+            : replay.stepExecutions.map((step) => (
+                <article key={step.stepId} className={`timeline-list__item timeline-list__item--${step.status}`}>
+                  <div className={`timeline-list__index timeline-list__index--${step.status}`} />
+                  <div>
+                    <h4>{step.title}</h4>
+                    <p>{step.summary ?? step.error ?? 'No step summary recorded.'}</p>
+                  </div>
+                  <div className="timeline-list__meta">
+                    <span className={`status-pill status-pill--${step.status}`}>{titleCaseStatus(step.status)}</span>
+                    <span>{step.assignedRole}</span>
+                    <span>{formatCredits(step.actualCredits)}</span>
+                  </div>
+                </article>
+              ))}
         </div>
       </section>
     </div>

--- a/apps/web/src/features/replay/ReplayPanel.tsx
+++ b/apps/web/src/features/replay/ReplayPanel.tsx
@@ -3,6 +3,14 @@ import type { Replay, Run } from '@agent-studio/contracts';
 import type { ControlPlaneSystemState } from '../../app/control-plane';
 import { getAgentLabel, getExecutionForRun, getExecutionMetrics, getExecutionSpans } from '../../app/control-plane';
 import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
+import {
+  buildReplayCompareNarrative,
+  buildReplaySpanTree,
+  formatSignedCreditsDelta,
+  formatSignedDurationDelta,
+  summarizeReplayComparison,
+  type ReplaySpanTreeNode,
+} from './replay-model';
 
 interface ReplayPanelProps {
   replay: Replay;
@@ -10,25 +18,88 @@ interface ReplayPanelProps {
   controlPlane?: ControlPlaneSystemState | null;
 }
 
+function getReplayStatusModifier(status: string) {
+  if (status === 'failed') {
+    return 'failed';
+  }
+
+  if (status === 'succeeded') {
+    return 'succeeded';
+  }
+
+  return 'mapped';
+}
+
+function getMetricCardClass(delta: number | null) {
+  if (delta == null || delta === 0) {
+    return 'metric-card';
+  }
+
+  return delta < 0 ? 'metric-card metric-card--success' : 'metric-card metric-card--warning';
+}
+
+function formatOptionalDuration(durationMs?: number) {
+  return durationMs == null ? '—' : formatDuration(durationMs);
+}
+
+function renderSpanTreeNode(node: ReplaySpanTreeNode, controlPlane?: ControlPlaneSystemState | null): React.ReactNode {
+  const modifier = getReplayStatusModifier(node.span.status);
+  const childCount = node.children.length;
+  const agentLabel = getAgentLabel(controlPlane, node.span.agentId) ?? node.span.kind;
+  const indexClassName =
+    modifier === 'mapped' ? 'timeline-list__index' : `timeline-list__index timeline-list__index--${modifier}`;
+
+  return (
+    <div key={node.span.spanId} className="replay-tree__node">
+      <article className={`timeline-list__item timeline-list__item--${modifier}`}>
+        <div className={indexClassName}>{node.depth + 1}</div>
+        <div>
+          <h4>{node.span.name}</h4>
+          <p>{node.span.summary ?? 'No span summary recorded.'}</p>
+          <div className="replay-tree__badges">
+            <span className="meta-chip">{node.span.parentSpanId ? 'Nested handoff' : 'Root span'}</span>
+            <span className="meta-chip">{childCount ? `${childCount} child span${childCount === 1 ? '' : 's'}` : 'Leaf span'}</span>
+          </div>
+        </div>
+        <div className="timeline-list__meta">
+          <span className={`status-pill status-pill--${node.span.status}`}>{titleCaseStatus(node.span.status)}</span>
+          <span>{agentLabel}</span>
+          <span>{formatCredits(node.span.usage?.credits)}</span>
+          <span>{formatOptionalDuration(node.span.usage?.durationMs)}</span>
+        </div>
+      </article>
+      {childCount ? <div className="replay-tree__children">{node.children.map((child) => renderSpanTreeNode(child, controlPlane))}</div> : null}
+    </div>
+  );
+}
+
 export function ReplayPanel({ replay, baselineRun, controlPlane }: ReplayPanelProps) {
-  const comparison = replay.operationalContext?.lastHealthyComparison;
   const failedStep = replay.stepExecutions.find((step) => step.status === 'failed');
   const execution = getExecutionForRun(controlPlane, replay.run.runId);
   const spans = getExecutionSpans(controlPlane, execution?.executionId);
   const executionMetrics = getExecutionMetrics(controlPlane, execution?.executionId);
+  const compareSummary = summarizeReplayComparison(replay, baselineRun, executionMetrics);
+  const compareNarrative = buildReplayCompareNarrative(compareSummary);
   const failedSpan = spans.find((span) => span.status === 'failed') ?? null;
-  const observedAgentCount = new Set(spans.map((span) => span.agentId).filter(Boolean)).size;
-  const creditsMetric = executionMetrics.find((metric) => metric.metric === 'credits.actual');
-  const durationMetric = executionMetrics.find((metric) => metric.metric === 'duration.ms');
+  const hasExecutionTree = Boolean(execution && spans.length > 0);
+  const spanTree = hasExecutionTree ? buildReplaySpanTree(spans) : null;
+  const observedAgentCount = spanTree?.stats.agentCount ?? new Set(spans.map((span) => span.agentId).filter(Boolean)).size;
   const replayHeadline =
     failedSpan?.summary ??
     failedStep?.summary ??
     failedSpan?.name ??
     failedStep?.title ??
     'The replay makes the decision point obvious.';
-  const replayBody = execution
-    ? `Replay is now reading the control-plane trace directly: ${spans.length} spans across ${observedAgentCount || 1} tracked agents in execution ${execution.executionId}.`
-    : 'Replay is there to show the exact break, not to bury it in generic analytics.';
+  const replayBody = hasExecutionTree
+    ? `Replay is reading the control-plane trace directly: ${spans.length} spans across ${observedAgentCount || 1} tracked agents in execution ${execution?.executionId}, pinned against ${compareSummary.baselineLabel}.`
+    : `Replay falls back to recorded step summaries when no execution trace is available, while still comparing ${compareSummary.selectedLabel} to ${compareSummary.baselineLabel}.`;
+  const compareCardClass =
+    compareSummary.creditsDelta != null &&
+    compareSummary.durationDeltaMs != null &&
+    compareSummary.creditsDelta <= 0 &&
+    compareSummary.durationDeltaMs <= 0
+      ? 'signal-band__card signal-band__card--accent'
+      : 'signal-band__card signal-band__card--directive';
 
   return (
     <div className="room-stack">
@@ -43,37 +114,62 @@ export function ReplayPanel({ replay, baselineRun, controlPlane }: ReplayPanelPr
         <p className="feature-summary">
           {replayHeadline} {replayBody}
         </p>
+        <div className="signal-band">
+          <article className="signal-band__card">
+            <span className="eyebrow">Baseline</span>
+            <strong>{compareSummary.baselineLabel}</strong>
+            <p>
+              <span className={`status-pill status-pill--${baselineRun.status}`}>{titleCaseStatus(baselineRun.status)}</span> ·{' '}
+              {formatCredits(compareSummary.baselineCredits)} · {formatOptionalDuration(compareSummary.baselineDurationMs)}
+            </p>
+            <p>Started {formatDateTime(baselineRun.startedAt)}</p>
+          </article>
+          <article className="signal-band__card signal-band__card--accent">
+            <span className="eyebrow">Selected replay</span>
+            <strong>{compareSummary.selectedLabel}</strong>
+            <p>
+              <span className={`status-pill status-pill--${replay.run.status}`}>{titleCaseStatus(replay.run.status)}</span> ·{' '}
+              {formatCredits(compareSummary.selectedCredits)} · {formatOptionalDuration(compareSummary.selectedDurationMs)}
+            </p>
+            <p>Started {formatDateTime(replay.run.startedAt)}</p>
+          </article>
+          <article className={compareCardClass}>
+            <span className="eyebrow">Compare readout</span>
+            <strong>
+              Spend {formatSignedCreditsDelta(compareSummary.creditsDelta)} / Time {formatSignedDurationDelta(compareSummary.durationDeltaMs)}
+            </strong>
+            <p>{compareNarrative}</p>
+          </article>
+        </div>
         <div className="metric-grid">
           <div className="metric-card metric-card--warning">
             <span>Failed at</span>
             <strong>{failedSpan?.name ?? failedStep?.title ?? 'No failed step'}</strong>
           </div>
-          <div className="metric-card">
-            <span>Actual spend</span>
-            <strong>{formatCredits(creditsMetric?.value ?? replay.run.actualCredits)}</strong>
+          <div className={getMetricCardClass(compareSummary.creditsDelta)}>
+            <span>Spend delta</span>
+            <strong>{formatSignedCreditsDelta(compareSummary.creditsDelta)}</strong>
           </div>
-          <div className="metric-card">
-            <span>Duration</span>
-            <strong>{formatDuration(durationMetric?.value ?? replay.run.durationMs)}</strong>
+          <div className={getMetricCardClass(compareSummary.durationDeltaMs)}>
+            <span>Duration delta</span>
+            <strong>{formatSignedDurationDelta(compareSummary.durationDeltaMs)}</strong>
           </div>
-          <div className="metric-card metric-card--primary">
-            <span>Healthy control</span>
-            <strong>{baselineRun.experimentLabel}</strong>
+          <div className={compareSummary.changedSignals.length ? 'metric-card metric-card--primary' : 'metric-card'}>
+            <span>Signals changed</span>
+            <strong>{compareSummary.changedSignals.length ? `${compareSummary.changedSignals.length} signals` : 'None recorded'}</strong>
           </div>
         </div>
-        {comparison ? (
-          <div className="inline-callout inline-callout--warning">
-            <span className="eyebrow">What drifted</span>
-            <p>{comparison.summary}</p>
-          </div>
-        ) : null}
+        <div className={`inline-callout${compareSummary.changedSignals.length ? ' inline-callout--warning' : ''}`}>
+          <span className="eyebrow">{compareSummary.changedSignals.length ? 'What changed from baseline' : 'Baseline readout'}</span>
+          <p>{compareNarrative}</p>
+        </div>
         {execution ? (
           <div className="inline-callout">
             <span className="eyebrow">Trace context</span>
             <p>
               Trace <strong>{execution.traceId}</strong> started {formatDateTime(execution.startedAt)} and is tied to{' '}
-              <strong>{controlPlane?.system.name ?? 'this system'}</strong>. This replay is using execution-native spans instead
-              of only flattened step summaries.
+              <strong>{controlPlane?.system.name ?? 'this system'}</strong>. This replay is using execution-native spans and{' '}
+              {spanTree ? `${spanTree.stats.rootCount} root branches with a deepest chain of ${spanTree.stats.maxDepth}.` : 'will fall back to flattened steps if the span tree is unavailable.'}
             </p>
           </div>
         ) : null}
@@ -83,31 +179,26 @@ export function ReplayPanel({ replay, baselineRun, controlPlane }: ReplayPanelPr
         <div className="section-header">
           <div>
             <p className="eyebrow">Run timeline</p>
-            <h3>{execution ? 'Execution and span replay' : 'Step-by-step replay'}</h3>
+            <h3>{hasExecutionTree ? 'Execution tree' : 'Step-by-step replay'}</h3>
           </div>
-          <span className="meta-chip">{execution ? `${spans.length} recorded spans` : `${replay.stepExecutions.length} recorded steps`}</span>
+          <span className="meta-chip">{hasExecutionTree ? `${spans.length} recorded spans` : `${replay.stepExecutions.length} recorded steps`}</span>
         </div>
-        <div className="timeline-list">
-          {execution
-            ? spans.map((span) => (
-                <article key={span.spanId} className={`timeline-list__item timeline-list__item--${span.status}`}>
-                  <div className={`timeline-list__index timeline-list__index--${span.status}`} />
-                  <div>
-                    <h4>{span.name}</h4>
-                    <p>
-                      {span.summary ?? 'No span summary recorded.'}
-                      {span.parentSpanId ? ` Linked from ${span.parentSpanId}.` : ''}
-                    </p>
-                  </div>
-                  <div className="timeline-list__meta">
-                    <span className={`status-pill status-pill--${span.status}`}>{titleCaseStatus(span.status)}</span>
-                    <span>{getAgentLabel(controlPlane, span.agentId) ?? span.kind}</span>
-                    <span>{formatCredits(span.usage?.credits)}</span>
-                    <span>{formatDuration(span.usage?.durationMs)}</span>
-                  </div>
-                </article>
-              ))
-            : replay.stepExecutions.map((step) => (
+        {hasExecutionTree && spanTree ? (
+          <>
+            <div className="replay-tree__summary">
+              <span className="meta-chip">{spanTree.stats.rootCount} root spans</span>
+              <span className="meta-chip">{spanTree.stats.nestedSpanCount} nested handoffs</span>
+              <span className="meta-chip">{spanTree.stats.maxDepth} levels deep</span>
+              <span className="meta-chip">{spanTree.stats.failedCount} failed spans</span>
+              <span className="meta-chip">
+                {spanTree.stats.agentCount ? `${spanTree.stats.agentCount} tracked agents` : 'No agent labels recorded'}
+              </span>
+            </div>
+            <div className="replay-tree">{spanTree.roots.map((node) => renderSpanTreeNode(node, controlPlane))}</div>
+          </>
+        ) : (
+          <div className="timeline-list">
+            {replay.stepExecutions.map((step) => (
                 <article key={step.stepId} className={`timeline-list__item timeline-list__item--${step.status}`}>
                   <div className={`timeline-list__index timeline-list__index--${step.status}`} />
                   <div>
@@ -121,7 +212,8 @@ export function ReplayPanel({ replay, baselineRun, controlPlane }: ReplayPanelPr
                   </div>
                 </article>
               ))}
-        </div>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/apps/web/src/features/replay/replay-model.ts
+++ b/apps/web/src/features/replay/replay-model.ts
@@ -1,0 +1,182 @@
+import type { MetricSample, Replay, Run, SpanRecord } from '@agent-studio/contracts';
+
+import { formatCredits, formatDuration } from '../../app/format';
+
+export interface ReplayComparisonSummary {
+  baselineLabel: string;
+  selectedLabel: string;
+  baselineCredits?: number;
+  selectedCredits?: number;
+  baselineDurationMs?: number;
+  selectedDurationMs?: number;
+  creditsDelta: number | null;
+  durationDeltaMs: number | null;
+  changedSignals: string[];
+  summary: string | null;
+}
+
+export interface ReplaySpanTreeNode {
+  span: SpanRecord;
+  depth: number;
+  children: ReplaySpanTreeNode[];
+}
+
+export interface ReplaySpanTreeStats {
+  rootCount: number;
+  nestedSpanCount: number;
+  leafCount: number;
+  maxDepth: number;
+  failedCount: number;
+  agentCount: number;
+}
+
+export interface ReplaySpanTree {
+  roots: ReplaySpanTreeNode[];
+  stats: ReplaySpanTreeStats;
+}
+
+function getMetricValue(metrics: MetricSample[], metric: string) {
+  return metrics.find((sample) => sample.metric === metric)?.value;
+}
+
+function getRunLabel(run: Run, fallback: string) {
+  return run.experimentLabel ?? run.branchName ?? run.runId ?? fallback;
+}
+
+function describeCreditsDelta(delta: number | null) {
+  if (delta == null) {
+    return null;
+  }
+
+  if (delta === 0) {
+    return 'matched spend';
+  }
+
+  return delta > 0 ? `spent ${formatCredits(delta)} more` : `spent ${formatCredits(Math.abs(delta))} less`;
+}
+
+function describeDurationDelta(deltaMs: number | null) {
+  if (deltaMs == null) {
+    return null;
+  }
+
+  if (deltaMs === 0) {
+    return 'finished in the same time';
+  }
+
+  return deltaMs > 0 ? `finished ${formatDuration(deltaMs)} slower` : `finished ${formatDuration(Math.abs(deltaMs))} faster`;
+}
+
+export function summarizeReplayComparison(replay: Replay, baselineRun: Run, executionMetrics: MetricSample[] = []): ReplayComparisonSummary {
+  const comparison = replay.operationalContext?.lastHealthyComparison;
+  const selectedCredits = getMetricValue(executionMetrics, 'credits.actual') ?? replay.run.actualCredits;
+  const selectedDurationMs = getMetricValue(executionMetrics, 'duration.ms') ?? replay.run.durationMs;
+  const baselineCredits = baselineRun.actualCredits;
+  const baselineDurationMs = baselineRun.durationMs;
+
+  return {
+    baselineLabel: getRunLabel(baselineRun, 'Healthy control'),
+    selectedLabel: getRunLabel(replay.run, 'Selected replay'),
+    baselineCredits,
+    selectedCredits,
+    baselineDurationMs,
+    selectedDurationMs,
+    creditsDelta: comparison?.creditsDelta ?? (selectedCredits != null && baselineCredits != null ? selectedCredits - baselineCredits : null),
+    durationDeltaMs:
+      comparison?.durationDelta ?? (selectedDurationMs != null && baselineDurationMs != null ? selectedDurationMs - baselineDurationMs : null),
+    changedSignals: comparison?.changedSignals ?? [],
+    summary: comparison?.summary ?? null,
+  };
+}
+
+export function buildReplayCompareNarrative(summary: ReplayComparisonSummary) {
+  if (summary.summary) {
+    return summary.summary;
+  }
+
+  const comparisonNotes = [describeCreditsDelta(summary.creditsDelta), describeDurationDelta(summary.durationDeltaMs)].filter(
+    (item): item is string => item != null,
+  );
+
+  if (!comparisonNotes.length) {
+    return `Healthy comparison notes were not recorded, so this view falls back to direct run metrics for ${summary.selectedLabel} versus ${summary.baselineLabel}.`;
+  }
+
+  return `${summary.selectedLabel} ${comparisonNotes.join(' and ')} than ${summary.baselineLabel}.`;
+}
+
+export function formatSignedCreditsDelta(delta: number | null | undefined) {
+  if (delta == null) {
+    return '—';
+  }
+
+  const prefix = delta > 0 ? '+' : '';
+  return `${prefix}${delta.toFixed(0)} cr`;
+}
+
+export function formatSignedDurationDelta(deltaMs: number | null | undefined) {
+  if (deltaMs == null) {
+    return '—';
+  }
+
+  const prefix = deltaMs > 0 ? '+' : deltaMs < 0 ? '-' : '';
+  return `${prefix}${formatDuration(Math.abs(deltaMs))}`;
+}
+
+export function buildReplaySpanTree(spans: SpanRecord[]): ReplaySpanTree {
+  const nodesById = new Map<string, ReplaySpanTreeNode>(
+    spans.map((span) => [
+      span.spanId,
+      {
+        span,
+        depth: 0,
+        children: [],
+      },
+    ]),
+  );
+  const roots: ReplaySpanTreeNode[] = [];
+
+  spans.forEach((span) => {
+    const node = nodesById.get(span.spanId);
+    if (!node) {
+      return;
+    }
+
+    const parent = span.parentSpanId ? nodesById.get(span.parentSpanId) : null;
+    if (parent) {
+      parent.children.push(node);
+      return;
+    }
+
+    roots.push(node);
+  });
+
+  let leafCount = 0;
+  let maxDepth = 0;
+
+  const assignDepth = (node: ReplaySpanTreeNode, depth: number) => {
+    node.depth = depth;
+    maxDepth = Math.max(maxDepth, depth + 1);
+
+    if (!node.children.length) {
+      leafCount += 1;
+      return;
+    }
+
+    node.children.forEach((child) => assignDepth(child, depth + 1));
+  };
+
+  roots.forEach((node) => assignDepth(node, 0));
+
+  return {
+    roots,
+    stats: {
+      rootCount: roots.length,
+      nestedSpanCount: spans.filter((span) => span.parentSpanId).length,
+      leafCount,
+      maxDepth,
+      failedCount: spans.filter((span) => span.status === 'failed').length,
+      agentCount: new Set(spans.map((span) => span.agentId).filter(Boolean)).size,
+    },
+  };
+}

--- a/apps/web/src/features/system/AgentDetailPanel.tsx
+++ b/apps/web/src/features/system/AgentDetailPanel.tsx
@@ -1,0 +1,111 @@
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { summarizeAgent } from '../../app/control-plane';
+import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
+
+interface AgentDetailPanelProps {
+  systemState: ControlPlaneSystemState | null;
+  agentId: string | null;
+}
+
+export function AgentDetailPanel({ systemState, agentId }: AgentDetailPanelProps) {
+  const summary = agentId ? summarizeAgent(systemState, agentId) : null;
+
+  if (!summary) {
+    return (
+      <section className="surface">
+        <div className="section-header">
+          <div>
+            <p className="eyebrow">Agent detail</p>
+            <h2>Select an agent</h2>
+          </div>
+        </div>
+        <p className="muted">Pick an agent from the fleet to inspect recent activity, directives, and runtime profile.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Agent detail</p>
+          <h2>{summary.agent.label}</h2>
+          <p className="muted">{summary.agent.role ?? summary.agent.kind}</p>
+        </div>
+        <span className={`status-pill status-pill--${summary.failedSpanCount > 0 ? 'failed' : summary.agent.status ?? 'active'}`}>
+          {titleCaseStatus(summary.failedSpanCount > 0 ? 'failed' : summary.agent.status ?? 'active')}
+        </span>
+      </div>
+      <div className="metric-grid">
+        <div className="metric-card">
+          <span>Spans</span>
+          <strong>{summary.spanCount}</strong>
+        </div>
+        <div className="metric-card metric-card--warning">
+          <span>Failures</span>
+          <strong>{summary.failedSpanCount}</strong>
+        </div>
+        <div className="metric-card metric-card--accent">
+          <span>Avg duration</span>
+          <strong>{formatDuration(summary.avgDurationMs)}</strong>
+        </div>
+        <div className="metric-card metric-card--primary">
+          <span>Total credits</span>
+          <strong>{formatCredits(summary.totalCredits)}</strong>
+        </div>
+      </div>
+      <div className="detail-stack">
+        <div className="mini-surface">
+          <p className="eyebrow">Runtime profile</p>
+          <div className="stack-list">
+            <div className="stack-list__item stack-list__item--body">
+              <strong>Version</strong>
+              <p>{summary.agent.version ?? 'Unknown version'}</p>
+            </div>
+            <div className="stack-list__item stack-list__item--body">
+              <strong>Capabilities</strong>
+              <p>{summary.agent.capabilities?.join(', ') || 'No capabilities recorded.'}</p>
+            </div>
+            <div className="stack-list__item stack-list__item--body">
+              <strong>Tools</strong>
+              <p>{summary.agent.toolRefs?.join(', ') || 'No tools recorded.'}</p>
+            </div>
+          </div>
+        </div>
+        <div className="mini-surface">
+          <p className="eyebrow">Latest trace</p>
+          <div className="stack-list">
+            <div className="stack-list__item stack-list__item--body">
+              <strong>{summary.latestSpan?.name ?? 'No span recorded.'}</strong>
+              <p>{summary.latestSpan?.summary ?? 'This agent has not emitted a traced span yet.'}</p>
+            </div>
+            {summary.latestSpan ? (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>{titleCaseStatus(summary.latestSpan.status)}</strong>
+                <p>
+                  {formatDateTime(summary.latestSpan.finishedAt ?? summary.latestSpan.startedAt)} ·{' '}
+                  {formatDuration(summary.latestSpan.usage?.durationMs)} · {formatCredits(summary.latestSpan.usage?.credits)}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="mini-surface">
+          <p className="eyebrow">Directive state</p>
+          <div className="stack-list">
+            <div className="stack-list__item stack-list__item--body">
+              <strong>{summary.activeInterventionCount} active directives</strong>
+              <p>{summary.latestIntervention?.reason ?? 'No intervention history recorded for this agent.'}</p>
+            </div>
+            {summary.latestIntervention ? (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>{summary.latestIntervention.action}</strong>
+                <p>{formatDateTime(summary.latestIntervention.appliedAt ?? summary.latestIntervention.requestedAt)}</p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/system/AgentFleetPanel.tsx
+++ b/apps/web/src/features/system/AgentFleetPanel.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from 'react';
+
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { summarizeAgents } from '../../app/control-plane';
+import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
+
+interface AgentFleetPanelProps {
+  systemState: ControlPlaneSystemState | null;
+  selectedAgentId: string | null;
+  onSelectAgent: (agentId: string) => void;
+}
+
+export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent }: AgentFleetPanelProps) {
+  const [query, setQuery] = useState('');
+  const agentSummaries = useMemo(() => summarizeAgents(systemState), [systemState]);
+  const filteredAgents = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return agentSummaries;
+    }
+
+    return agentSummaries.filter((summary) => {
+      const haystacks = [
+        summary.agent.label,
+        summary.agent.role,
+        summary.agent.kind,
+        ...(summary.agent.capabilities ?? []),
+        ...(summary.agent.toolRefs ?? []),
+      ]
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value) => value.toLowerCase());
+
+      return haystacks.some((value) => value.includes(normalizedQuery));
+    });
+  }, [agentSummaries, query]);
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Agent fleet</p>
+          <h2>Searchable agent roster</h2>
+          <p className="muted">This is the scalable primary surface. Use the roster to find the hot agent first, then use Live for topology context.</p>
+        </div>
+        <span className="meta-chip">{filteredAgents.length} visible</span>
+      </div>
+      <label className="text-field">
+        <span>Filter agents</span>
+        <input
+          aria-label="Filter agents"
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by role, capability, tool, or agent name"
+        />
+      </label>
+      <div className="agent-fleet__list">
+        {filteredAgents.map((summary) => (
+          <button
+            key={summary.agent.agentId}
+            type="button"
+            className={`agent-row ${selectedAgentId === summary.agent.agentId ? 'agent-row--active' : ''}`}
+            onClick={() => onSelectAgent(summary.agent.agentId)}
+          >
+            <div className="agent-row__identity">
+              <strong>{summary.agent.label}</strong>
+              <span>{summary.agent.role ?? summary.agent.kind}</span>
+            </div>
+            <div className="agent-row__metrics">
+              <span className={`status-pill status-pill--${summary.failedSpanCount > 0 ? 'failed' : summary.agent.status ?? 'active'}`}>
+                {titleCaseStatus(summary.failedSpanCount > 0 ? 'failed' : summary.agent.status ?? 'active')}
+              </span>
+              <span>{summary.spanCount} spans</span>
+              <span>{Math.round(summary.successRate * 100)}% success</span>
+              <span>{formatDuration(summary.avgDurationMs)}</span>
+              <span>{formatCredits(summary.avgCredits)}</span>
+              <span>{summary.activeInterventionCount} directives</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/system/AgentFleetPanel.tsx
+++ b/apps/web/src/features/system/AgentFleetPanel.tsx
@@ -1,25 +1,35 @@
 import { useMemo, useState } from 'react';
 
-import type { ControlPlaneSystemState } from '../../app/control-plane';
-import { summarizeAgents } from '../../app/control-plane';
+import type { AgentRosterFocus, AnalyticsWindow, ControlPlaneSystemState } from '../../app/control-plane';
+import { filterAgentSummaries, getAnalyticsWindowLabel, summarizeAgents } from '../../app/control-plane';
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface AgentFleetPanelProps {
   systemState: ControlPlaneSystemState | null;
   selectedAgentId: string | null;
   onSelectAgent: (agentId: string) => void;
+  analyticsWindow: AnalyticsWindow;
 }
 
-export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent }: AgentFleetPanelProps) {
+const FOCUS_OPTIONS: Array<{ id: AgentRosterFocus; label: string }> = [
+  { id: 'all', label: 'All agents' },
+  { id: 'attention', label: 'Needs attention' },
+  { id: 'failures', label: 'Failures' },
+  { id: 'directives', label: 'Directives' },
+];
+
+export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent, analyticsWindow }: AgentFleetPanelProps) {
   const [query, setQuery] = useState('');
+  const [focus, setFocus] = useState<AgentRosterFocus>('all');
   const agentSummaries = useMemo(() => summarizeAgents(systemState), [systemState]);
   const filteredAgents = useMemo(() => {
+    const focusedAgents = filterAgentSummaries(agentSummaries, focus);
     const normalizedQuery = query.trim().toLowerCase();
     if (!normalizedQuery) {
-      return agentSummaries;
+      return focusedAgents;
     }
 
-    return agentSummaries.filter((summary) => {
+    return focusedAgents.filter((summary) => {
       const haystacks = [
         summary.agent.label,
         summary.agent.role,
@@ -32,7 +42,7 @@ export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent }:
 
       return haystacks.some((value) => value.includes(normalizedQuery));
     });
-  }, [agentSummaries, query]);
+  }, [agentSummaries, focus, query]);
 
   return (
     <section className="surface">
@@ -42,7 +52,9 @@ export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent }:
           <h2>Searchable agent roster</h2>
           <p className="muted">This is the scalable primary surface. Use the roster to find the hot agent first, then use Live for topology context.</p>
         </div>
-        <span className="meta-chip">{filteredAgents.length} visible</span>
+        <span className="meta-chip">
+          {filteredAgents.length} visible · {getAnalyticsWindowLabel(analyticsWindow)}
+        </span>
       </div>
       <label className="text-field">
         <span>Filter agents</span>
@@ -54,6 +66,18 @@ export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent }:
           placeholder="Search by role, capability, tool, or agent name"
         />
       </label>
+      <div className="history-toolbar">
+        {FOCUS_OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            className={`history-filter ${focus === option.id ? 'history-filter--active' : ''}`}
+            onClick={() => setFocus(option.id)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
       <div className="agent-fleet__list">
         {filteredAgents.map((summary) => (
           <button
@@ -78,6 +102,12 @@ export function AgentFleetPanel({ systemState, selectedAgentId, onSelectAgent }:
             </div>
           </button>
         ))}
+        {!filteredAgents.length ? (
+          <div className="stack-list__item stack-list__item--body">
+            <strong>No agents match the current fleet filter</strong>
+            <p>Broaden the focus or time window to bring more of the fleet back into view.</p>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/web/src/features/system/FleetAnalyticsPanel.tsx
+++ b/apps/web/src/features/system/FleetAnalyticsPanel.tsx
@@ -1,12 +1,13 @@
-import type { ControlPlaneSystemState } from '../../app/control-plane';
-import { summarizeFleetAnalytics } from '../../app/control-plane';
-import { formatDateTime, titleCaseStatus } from '../../app/format';
+import type { AnalyticsWindow, ControlPlaneSystemState } from '../../app/control-plane';
+import { getAnalyticsWindowLabel, summarizeFleetAnalytics } from '../../app/control-plane';
+import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface FleetAnalyticsPanelProps {
   systemState: ControlPlaneSystemState | null;
+  analyticsWindow: AnalyticsWindow;
 }
 
-export function FleetAnalyticsPanel({ systemState }: FleetAnalyticsPanelProps) {
+export function FleetAnalyticsPanel({ systemState, analyticsWindow }: FleetAnalyticsPanelProps) {
   const analytics = summarizeFleetAnalytics(systemState);
 
   if (!analytics) {
@@ -24,7 +25,9 @@ export function FleetAnalyticsPanel({ systemState }: FleetAnalyticsPanelProps) {
             release evidence into something an operator can scan fast.
           </p>
         </div>
-        <span className="meta-chip">{analytics.recentEventCount7d} events in 7d</span>
+        <span className="meta-chip">
+          {analytics.eventCount} events · {getAnalyticsWindowLabel(analyticsWindow)}
+        </span>
       </div>
       <div className="analytics-grid">
         <article className="metric-card metric-card--primary">
@@ -41,12 +44,12 @@ export function FleetAnalyticsPanel({ systemState }: FleetAnalyticsPanelProps) {
           </strong>
         </article>
         <article className="metric-card metric-card--accent">
-          <span>Active directives</span>
-          <strong>{analytics.activeDirectives}</strong>
+          <span>Average spend</span>
+          <strong>{formatCredits(analytics.avgCredits)}</strong>
         </article>
         <article className="metric-card metric-card--success">
-          <span>Recent activity</span>
-          <strong>{analytics.recentEventCount24h} in last 24h</strong>
+          <span>Average duration</span>
+          <strong>{formatDuration(analytics.avgDurationMs)}</strong>
         </article>
       </div>
       <div className="analytics-columns">
@@ -72,8 +75,15 @@ export function FleetAnalyticsPanel({ systemState }: FleetAnalyticsPanelProps) {
           </div>
         </section>
         <section className="mini-surface">
-          <p className="eyebrow">Recent failures and holds</p>
+          <p className="eyebrow">Window posture</p>
           <div className="stack-list">
+            <div className="stack-list__item stack-list__item--body">
+              <strong>{analytics.executionCount} tracked execution{analytics.executionCount === 1 ? '' : 's'}</strong>
+              <p>
+                {Math.round(analytics.successRate * 100)}% success · {analytics.activeDirectives} active directives ·
+                latest event {formatDateTime(analytics.latestEventAt ?? undefined)}
+              </p>
+            </div>
             {analytics.recentFailures.length ? (
               analytics.recentFailures.map((event) => (
                 <div key={event.eventId} className="stack-list__item stack-list__item--body">
@@ -85,8 +95,8 @@ export function FleetAnalyticsPanel({ systemState }: FleetAnalyticsPanelProps) {
               ))
             ) : (
               <div className="stack-list__item stack-list__item--body">
-                <strong>No recent failures</strong>
-                <p>The current history does not show failed executions, hold evaluations, or rollback releases.</p>
+                <strong>No failures or holds in this window</strong>
+                <p>The selected time scope does not show failed executions, hold evaluations, or rollback releases.</p>
               </div>
             )}
           </div>

--- a/apps/web/src/features/system/FleetAnalyticsPanel.tsx
+++ b/apps/web/src/features/system/FleetAnalyticsPanel.tsx
@@ -1,0 +1,97 @@
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { summarizeFleetAnalytics } from '../../app/control-plane';
+import { formatDateTime, titleCaseStatus } from '../../app/format';
+
+interface FleetAnalyticsPanelProps {
+  systemState: ControlPlaneSystemState | null;
+}
+
+export function FleetAnalyticsPanel({ systemState }: FleetAnalyticsPanelProps) {
+  const analytics = summarizeFleetAnalytics(systemState);
+
+  if (!analytics) {
+    return null;
+  }
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Fleet analytics</p>
+          <h2>Pressure, failures, and recent activity</h2>
+          <p className="muted">
+            This is the first real history layer for the system. It turns persisted executions, spans, directives, and
+            release evidence into something an operator can scan fast.
+          </p>
+        </div>
+        <span className="meta-chip">{analytics.recentEventCount7d} events in 7d</span>
+      </div>
+      <div className="analytics-grid">
+        <article className="metric-card metric-card--primary">
+          <span>Execution mix</span>
+          <strong>
+            {analytics.executionStatusCounts.succeeded} ok · {analytics.executionStatusCounts.running} running ·{' '}
+            {analytics.executionStatusCounts.failed} failed
+          </strong>
+        </article>
+        <article className="metric-card metric-card--warning">
+          <span>Span health</span>
+          <strong>
+            {analytics.failedSpans} failed of {analytics.totalSpans}
+          </strong>
+        </article>
+        <article className="metric-card metric-card--accent">
+          <span>Active directives</span>
+          <strong>{analytics.activeDirectives}</strong>
+        </article>
+        <article className="metric-card metric-card--success">
+          <span>Recent activity</span>
+          <strong>{analytics.recentEventCount24h} in last 24h</strong>
+        </article>
+      </div>
+      <div className="analytics-columns">
+        <section className="mini-surface">
+          <p className="eyebrow">Pressure leaderboard</p>
+          <div className="stack-list">
+            {analytics.hottestAgents.length ? (
+              analytics.hottestAgents.map((agent) => (
+                <div key={agent.agent.agentId} className="stack-list__item stack-list__item--body">
+                  <strong>{agent.agent.label}</strong>
+                  <p>
+                    {agent.failedSpanCount} failed spans · {agent.activeInterventionCount} active directives · last
+                    active {formatDateTime(agent.lastActiveAt ?? undefined)}
+                  </p>
+                </div>
+              ))
+            ) : (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>No hot agents yet</strong>
+                <p>Import more spans and directives to build a real pressure leaderboard.</p>
+              </div>
+            )}
+          </div>
+        </section>
+        <section className="mini-surface">
+          <p className="eyebrow">Recent failures and holds</p>
+          <div className="stack-list">
+            {analytics.recentFailures.length ? (
+              analytics.recentFailures.map((event) => (
+                <div key={event.eventId} className="stack-list__item stack-list__item--body">
+                  <strong>{event.title}</strong>
+                  <p>
+                    {titleCaseStatus(event.status)} · {formatDateTime(event.occurredAt)} · {event.summary}
+                  </p>
+                </div>
+              ))
+            ) : (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>No recent failures</strong>
+                <p>The current history does not show failed executions, hold evaluations, or rollback releases.</p>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/system/FleetOverviewPanel.tsx
+++ b/apps/web/src/features/system/FleetOverviewPanel.tsx
@@ -1,0 +1,139 @@
+import type { AnalyticsWindow, ControlPlaneSystemState } from '../../app/control-plane';
+import { getAgentLabel, getAnalyticsWindowLabel, summarizeFleet } from '../../app/control-plane';
+import { formatCredits, formatDateTime, formatDuration, titleCaseStatus } from '../../app/format';
+
+interface FleetOverviewPanelProps {
+  systems: ControlPlaneSystemState[];
+  analyticsWindow: AnalyticsWindow;
+  onSelectSystem: (systemId: string) => void;
+}
+
+export function FleetOverviewPanel({ systems, analyticsWindow, onSelectSystem }: FleetOverviewPanelProps) {
+  const fleet = summarizeFleet(systems);
+
+  if (!fleet.systemCount) {
+    return null;
+  }
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Fleet overview</p>
+          <h2>Cross-system pressure and release watch</h2>
+          <p className="muted">
+            This is the fleet-level control plane. It shows what needs attention across systems before you drill into a
+            single agent topology or replay tree.
+          </p>
+        </div>
+        <span className="meta-chip">{getAnalyticsWindowLabel(analyticsWindow)} window</span>
+      </div>
+
+      <div className="analytics-grid">
+        <article className="metric-card metric-card--primary">
+          <span>Systems in view</span>
+          <strong>
+            {fleet.activeSystemCount} active of {fleet.systemCount}
+          </strong>
+        </article>
+        <article className="metric-card">
+          <span>Tracked agents</span>
+          <strong>{fleet.trackedAgentCount}</strong>
+        </article>
+        <article className="metric-card metric-card--accent">
+          <span>Execution volume</span>
+          <strong>{fleet.executionCount}</strong>
+        </article>
+        <article className="metric-card metric-card--success">
+          <span>Fleet success rate</span>
+          <strong>{Math.round(fleet.avgSuccessRate * 100)}%</strong>
+        </article>
+      </div>
+
+      <div className="analytics-columns">
+        <section className="mini-surface">
+          <p className="eyebrow">Pressure leaderboard</p>
+          <div className="stack-list">
+            {fleet.hottestSystems.length ? (
+              fleet.hottestSystems.map((summary) => (
+                <button
+                  key={summary.system.systemId}
+                  type="button"
+                  className="stack-list__item stack-list__item--body stack-list__button"
+                  onClick={() => onSelectSystem(summary.system.systemId)}
+                >
+                  <strong>{summary.system.name}</strong>
+                  <p>
+                    {summary.activeInterventionCount} directives · {summary.executionCount} executions · pressure{' '}
+                    {getAgentLabel(
+                      systems.find((systemState) => systemState.system.systemId === summary.system.systemId) ?? null,
+                      summary.pressureAgentId ?? undefined,
+                    ) ?? 'No hot agent'}
+                  </p>
+                </button>
+              ))
+            ) : (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>No hot systems yet</strong>
+                <p>Import more systems and traces to build a real fleet pressure picture.</p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="mini-surface">
+          <p className="eyebrow">Release watchlist</p>
+          <div className="stack-list">
+            {fleet.releaseWatchlist.length ? (
+              fleet.releaseWatchlist.map((summary) => (
+                <button
+                  key={summary.system.systemId}
+                  type="button"
+                  className="stack-list__item stack-list__item--body stack-list__button"
+                  onClick={() => onSelectSystem(summary.system.systemId)}
+                >
+                  <strong>{summary.system.name}</strong>
+                  <p>
+                    {titleCaseStatus(summary.latestRelease?.decision ?? summary.latestEvaluation?.verdict ?? 'watch')} ·{' '}
+                    {summary.latestRelease?.summary ?? summary.latestEvaluation?.summary ?? 'Release review still open.'}
+                  </p>
+                </button>
+              ))
+            ) : (
+              <div className="stack-list__item stack-list__item--body">
+                <strong>No release holds in this window</strong>
+                <p>The current fleet slice does not show hold or rollback pressure.</p>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <div className="signal-band">
+        <article className="signal-band__card">
+          <p className="eyebrow">Average spend</p>
+          <strong>{formatCredits(fleet.avgCredits)}</strong>
+          <p>Average execution cost across the systems in this window.</p>
+        </article>
+        <article className="signal-band__card signal-band__card--accent">
+          <p className="eyebrow">Average duration</p>
+          <strong>{formatDuration(fleet.avgDurationMs)}</strong>
+          <p>Average execution duration across the systems in this window.</p>
+        </article>
+        <article className="signal-band__card signal-band__card--directive">
+          <p className="eyebrow">Directive load</p>
+          <strong>{fleet.activeDirectiveCount} active directives</strong>
+          <p>
+            {fleet.releaseWatchlist[0]
+              ? `Latest watch item ${fleet.releaseWatchlist[0].system.name} · ${formatDateTime(
+                  fleet.releaseWatchlist[0].latestRelease?.appliedAt ??
+                    fleet.releaseWatchlist[0].latestRelease?.requestedAt ??
+                    fleet.releaseWatchlist[0].latestEvaluation?.createdAt,
+                )}`
+              : 'No active release watch item in this window.'}
+          </p>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/system/SystemCatalogPanel.tsx
+++ b/apps/web/src/features/system/SystemCatalogPanel.tsx
@@ -1,0 +1,77 @@
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { getAgentLabel, summarizeSystem } from '../../app/control-plane';
+import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
+
+interface SystemCatalogPanelProps {
+  systems: ControlPlaneSystemState[];
+  selectedSystemId: string | null;
+  onSelectSystem: (systemId: string) => void;
+}
+
+export function SystemCatalogPanel({ systems, selectedSystemId, onSelectSystem }: SystemCatalogPanelProps) {
+  return (
+    <section className="surface system-catalog">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">System catalog</p>
+          <h2>Registered systems</h2>
+          <p className="muted">Pick the system you want to operate, then use Live, Replay, and Optimize against that system instead of a loose demo workflow.</p>
+        </div>
+        <span className="meta-chip">{systems.length} system{systems.length === 1 ? '' : 's'}</span>
+      </div>
+      <div className="system-catalog__grid">
+        {systems.map((systemState) => {
+          const summary = summarizeSystem(systemState);
+          if (!summary) {
+            return null;
+          }
+
+          const pressureAgentLabel = getAgentLabel(systemState, summary.pressureAgentId ?? undefined);
+
+          return (
+            <button
+              key={systemState.system.systemId}
+              type="button"
+              className={`system-card ${selectedSystemId === systemState.system.systemId ? 'system-card--active' : ''}`}
+              onClick={() => onSelectSystem(systemState.system.systemId)}
+            >
+              <div className="system-card__header">
+                <div>
+                  <p className="eyebrow">System</p>
+                  <h3>{summary.system.name}</h3>
+                </div>
+                <span className={`status-pill status-pill--${summary.latestExecution?.status ?? summary.system.status ?? 'active'}`}>
+                  {titleCaseStatus(summary.latestExecution?.status ?? summary.system.status ?? 'active')}
+                </span>
+              </div>
+              <p className="system-card__summary">{summary.system.description ?? 'No system description recorded yet.'}</p>
+              <div className="system-card__metrics">
+                <div>
+                  <span>Agents</span>
+                  <strong>{summary.agentCount}</strong>
+                </div>
+                <div>
+                  <span>Executions</span>
+                  <strong>{summary.executionCount}</strong>
+                </div>
+                <div>
+                  <span>Avg spend</span>
+                  <strong>{formatCredits(summary.avgCredits)}</strong>
+                </div>
+                <div>
+                  <span>Avg duration</span>
+                  <strong>{formatDuration(summary.avgDurationMs)}</strong>
+                </div>
+              </div>
+              <div className="system-card__footer">
+                <span className="meta-chip">{Math.round(summary.successRate * 100)}% success</span>
+                <span className="meta-chip">{summary.activeInterventionCount} active directives</span>
+                {pressureAgentLabel ? <span className="meta-chip">Pressure: {pressureAgentLabel}</span> : null}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/system/SystemCatalogPanel.tsx
+++ b/apps/web/src/features/system/SystemCatalogPanel.tsx
@@ -1,5 +1,13 @@
+import { useMemo, useState } from 'react';
+
 import type { ControlPlaneSystemState } from '../../app/control-plane';
-import { getAgentLabel, summarizeSystem } from '../../app/control-plane';
+import {
+  filterSystemSummaries,
+  getAgentLabel,
+  SYSTEM_CATALOG_FOCUS_OPTIONS,
+  summarizeSystem,
+  type SystemCatalogFocus,
+} from '../../app/control-plane';
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface SystemCatalogPanelProps {
@@ -9,6 +17,49 @@ interface SystemCatalogPanelProps {
 }
 
 export function SystemCatalogPanel({ systems, selectedSystemId, onSelectSystem }: SystemCatalogPanelProps) {
+  const [query, setQuery] = useState('');
+  const [focus, setFocus] = useState<SystemCatalogFocus>('all');
+  const summaries = useMemo(
+    () =>
+      systems
+        .map((systemState) => ({
+          systemState,
+          summary: summarizeSystem(systemState),
+        }))
+        .filter((item): item is { systemState: ControlPlaneSystemState; summary: NonNullable<ReturnType<typeof summarizeSystem>> } => item.summary != null),
+    [systems],
+  );
+  const filteredSystems = useMemo(() => {
+    const focused = filterSystemSummaries(
+      summaries.map((item) => item.summary),
+      focus,
+    );
+    const focusedIds = new Set(focused.map((summary) => summary.system.systemId));
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return summaries.filter(({ systemState, summary }) => {
+      if (!focusedIds.has(summary.system.systemId)) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      const haystacks = [
+        summary.system.name,
+        summary.system.description,
+        ...summary.system.runtimeIds,
+        ...systemState.agents.map((agent) => agent.label),
+        ...systemState.agents.map((agent) => agent.role),
+      ]
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value) => value.toLowerCase());
+
+      return haystacks.some((value) => value.includes(normalizedQuery));
+    });
+  }, [focus, query, summaries]);
+
   return (
     <section className="surface system-catalog">
       <div className="section-header">
@@ -17,15 +68,32 @@ export function SystemCatalogPanel({ systems, selectedSystemId, onSelectSystem }
           <h2>Registered systems</h2>
           <p className="muted">Pick the system you want to operate, then use Live, Replay, and Optimize against that system instead of a loose demo workflow.</p>
         </div>
-        <span className="meta-chip">{systems.length} system{systems.length === 1 ? '' : 's'}</span>
+        <span className="meta-chip">{filteredSystems.length} visible</span>
+      </div>
+      <label className="text-field">
+        <span>Filter systems</span>
+        <input
+          aria-label="Filter systems"
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by system, runtime, or agent"
+        />
+      </label>
+      <div className="history-toolbar">
+        {SYSTEM_CATALOG_FOCUS_OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            className={`history-filter ${focus === option.id ? 'history-filter--active' : ''}`}
+            onClick={() => setFocus(option.id)}
+          >
+            {option.label}
+          </button>
+        ))}
       </div>
       <div className="system-catalog__grid">
-        {systems.map((systemState) => {
-          const summary = summarizeSystem(systemState);
-          if (!summary) {
-            return null;
-          }
-
+        {filteredSystems.map(({ systemState, summary }) => {
           const pressureAgentLabel = getAgentLabel(systemState, summary.pressureAgentId ?? undefined);
 
           return (
@@ -71,6 +139,12 @@ export function SystemCatalogPanel({ systems, selectedSystemId, onSelectSystem }
             </button>
           );
         })}
+        {!filteredSystems.length ? (
+          <div className="stack-list__item stack-list__item--body">
+            <strong>No systems match the current filter</strong>
+            <p>Broaden the focus or search query to bring more of the fleet back into view.</p>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/web/src/features/system/SystemHistoryPanel.tsx
+++ b/apps/web/src/features/system/SystemHistoryPanel.tsx
@@ -1,13 +1,15 @@
 import { useMemo, useState } from 'react';
 
-import type { SystemHistoryEvent, ControlPlaneSystemState } from '../../app/control-plane';
-import { buildSystemHistoryEvents, getAgentLabel } from '../../app/control-plane';
+import type { AnalyticsWindow, SystemHistoryEvent, ControlPlaneSystemState } from '../../app/control-plane';
+import { buildSystemHistoryEvents, getAgentLabel, getAnalyticsWindowLabel } from '../../app/control-plane';
 import { formatDateTime, titleCaseStatus } from '../../app/format';
 
 type HistoryFilter = 'all' | SystemHistoryEvent['kind'];
+type HistoryStatusFilter = 'all' | 'attention' | 'healthy' | 'active';
 
 interface SystemHistoryPanelProps {
   systemState: ControlPlaneSystemState | null;
+  analyticsWindow: AnalyticsWindow;
 }
 
 const FILTERS: Array<{ id: HistoryFilter; label: string }> = [
@@ -18,16 +20,39 @@ const FILTERS: Array<{ id: HistoryFilter; label: string }> = [
   { id: 'release', label: 'Releases' },
 ];
 
-export function SystemHistoryPanel({ systemState }: SystemHistoryPanelProps) {
+const STATUS_FILTERS: Array<{ id: HistoryStatusFilter; label: string }> = [
+  { id: 'all', label: 'All statuses' },
+  { id: 'attention', label: 'Attention' },
+  { id: 'healthy', label: 'Healthy' },
+  { id: 'active', label: 'Active' },
+];
+
+function matchesStatusFilter(event: SystemHistoryEvent, filter: HistoryStatusFilter) {
+  if (filter === 'all') {
+    return true;
+  }
+
+  if (filter === 'attention') {
+    return ['failed', 'hold', 'rollback'].includes(event.status);
+  }
+
+  if (filter === 'healthy') {
+    return ['succeeded', 'approved', 'promoted', 'released'].includes(event.status);
+  }
+
+  return ['running', 'active', 'applied', 'recorded'].includes(event.status);
+}
+
+export function SystemHistoryPanel({ systemState, analyticsWindow }: SystemHistoryPanelProps) {
   const [filter, setFilter] = useState<HistoryFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<HistoryStatusFilter>('all');
   const history = useMemo(() => buildSystemHistoryEvents(systemState), [systemState]);
   const filteredHistory = useMemo(() => {
-    if (filter === 'all') {
-      return history;
-    }
-
-    return history.filter((event) => event.kind === filter);
-  }, [filter, history]);
+    return history.filter((event) => {
+      const matchesKind = filter === 'all' ? true : event.kind === filter;
+      return matchesKind && matchesStatusFilter(event, statusFilter);
+    });
+  }, [filter, history, statusFilter]);
 
   if (!systemState) {
     return null;
@@ -44,7 +69,9 @@ export function SystemHistoryPanel({ systemState }: SystemHistoryPanelProps) {
             stream.
           </p>
         </div>
-        <span className="meta-chip">{history.length} events</span>
+        <span className="meta-chip">
+          {filteredHistory.length} events · {getAnalyticsWindowLabel(analyticsWindow)}
+        </span>
       </div>
       <div className="history-toolbar">
         {FILTERS.map((item) => (
@@ -53,6 +80,18 @@ export function SystemHistoryPanel({ systemState }: SystemHistoryPanelProps) {
             type="button"
             className={`history-filter ${filter === item.id ? 'history-filter--active' : ''}`}
             onClick={() => setFilter(item.id)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="history-toolbar">
+        {STATUS_FILTERS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={`history-filter ${statusFilter === item.id ? 'history-filter--active' : ''}`}
+            onClick={() => setStatusFilter(item.id)}
           >
             {item.label}
           </button>

--- a/apps/web/src/features/system/SystemHistoryPanel.tsx
+++ b/apps/web/src/features/system/SystemHistoryPanel.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'react';
+
+import type { SystemHistoryEvent, ControlPlaneSystemState } from '../../app/control-plane';
+import { buildSystemHistoryEvents, getAgentLabel } from '../../app/control-plane';
+import { formatDateTime, titleCaseStatus } from '../../app/format';
+
+type HistoryFilter = 'all' | SystemHistoryEvent['kind'];
+
+interface SystemHistoryPanelProps {
+  systemState: ControlPlaneSystemState | null;
+}
+
+const FILTERS: Array<{ id: HistoryFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'execution', label: 'Executions' },
+  { id: 'directive', label: 'Directives' },
+  { id: 'evaluation', label: 'Evaluations' },
+  { id: 'release', label: 'Releases' },
+];
+
+export function SystemHistoryPanel({ systemState }: SystemHistoryPanelProps) {
+  const [filter, setFilter] = useState<HistoryFilter>('all');
+  const history = useMemo(() => buildSystemHistoryEvents(systemState), [systemState]);
+  const filteredHistory = useMemo(() => {
+    if (filter === 'all') {
+      return history;
+    }
+
+    return history.filter((event) => event.kind === filter);
+  }, [filter, history]);
+
+  if (!systemState) {
+    return null;
+  }
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Recent history</p>
+          <h2>What changed in this system</h2>
+          <p className="muted">
+            This is the queryable operator timeline: executions, directives, evaluations, and release decisions in one
+            stream.
+          </p>
+        </div>
+        <span className="meta-chip">{history.length} events</span>
+      </div>
+      <div className="history-toolbar">
+        {FILTERS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={`history-filter ${filter === item.id ? 'history-filter--active' : ''}`}
+            onClick={() => setFilter(item.id)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="history-timeline">
+        {filteredHistory.length ? (
+          filteredHistory.slice(0, 10).map((event) => {
+            const agentLabel = event.relatedAgentId ? getAgentLabel(systemState, event.relatedAgentId) : null;
+
+            return (
+              <article key={event.eventId} className="history-item">
+                <div className="history-item__header">
+                  <div>
+                    <p className="eyebrow">{titleCaseStatus(event.kind)}</p>
+                    <h3>{event.title}</h3>
+                  </div>
+                  <span className={`status-pill status-pill--${event.status === 'hold' ? 'failed' : event.status}`}>
+                    {titleCaseStatus(event.status)}
+                  </span>
+                </div>
+                <p className="history-item__summary">{event.summary}</p>
+                <div className="history-item__meta">
+                  <span>{formatDateTime(event.occurredAt)}</span>
+                  {agentLabel ? <span>{agentLabel}</span> : null}
+                  {event.relatedExecutionId ? <span>{event.relatedExecutionId}</span> : null}
+                </div>
+              </article>
+            );
+          })
+        ) : (
+          <article className="history-item">
+            <div className="history-item__header">
+              <div>
+                <p className="eyebrow">No history</p>
+                <h3>No matching events yet</h3>
+              </div>
+            </div>
+            <p className="history-item__summary">Import traces, directives, evaluations, or releases to populate the operator timeline.</p>
+          </article>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/system/SystemOverviewRoute.tsx
+++ b/apps/web/src/features/system/SystemOverviewRoute.tsx
@@ -1,5 +1,5 @@
 import type { DemoState, WorkflowDemoState } from '../../app/demo';
-import { getAgentLabel, summarizeSystem, type ControlPlaneSystemState } from '../../app/control-plane';
+import { getAgentLabel, summarizeSystem, type ControlPlaneStorageInfo, type ControlPlaneSystemState } from '../../app/control-plane';
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 import { AgentDetailPanel } from './AgentDetailPanel';
 import { AgentFleetPanel } from './AgentFleetPanel';
@@ -11,6 +11,7 @@ interface SystemOverviewRouteProps {
   sortedSystems: ControlPlaneSystemState[];
   selectedSystem: ControlPlaneSystemState | null;
   selectedWorkflowState: WorkflowDemoState | null;
+  storage: ControlPlaneStorageInfo | null;
   selectedAgentId: string | null;
   onSelectSystem: (systemId: string) => void;
   onSelectAgent: (agentId: string) => void;
@@ -29,6 +30,7 @@ export function SystemOverviewRoute({
   sortedSystems,
   selectedSystem,
   selectedWorkflowState,
+  storage,
   selectedAgentId,
   onSelectSystem,
   onSelectAgent,
@@ -60,7 +62,7 @@ export function SystemOverviewRoute({
           </section>
         ) : null}
 
-        {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} /> : null}
+        {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} storage={storage} /> : null}
 
         <section className="surface overview-panel">
           <div className="section-header">
@@ -175,7 +177,7 @@ export function SystemOverviewRoute({
         </section>
       ) : null}
 
-      {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} /> : null}
+      {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} storage={storage} /> : null}
 
       <section className="surface overview-panel">
         <div className="section-header">

--- a/apps/web/src/features/system/SystemOverviewRoute.tsx
+++ b/apps/web/src/features/system/SystemOverviewRoute.tsx
@@ -3,7 +3,9 @@ import { getAgentLabel, summarizeSystem, type ControlPlaneStorageInfo, type Cont
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 import { AgentDetailPanel } from './AgentDetailPanel';
 import { AgentFleetPanel } from './AgentFleetPanel';
+import { FleetAnalyticsPanel } from './FleetAnalyticsPanel';
 import { SystemCatalogPanel } from './SystemCatalogPanel';
+import { SystemHistoryPanel } from './SystemHistoryPanel';
 import { SystemPerformancePanel } from './SystemPerformancePanel';
 
 interface SystemOverviewRouteProps {
@@ -63,6 +65,8 @@ export function SystemOverviewRoute({
         ) : null}
 
         {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} storage={storage} /> : null}
+        {selectedSystem ? <FleetAnalyticsPanel systemState={selectedSystem} /> : null}
+        {selectedSystem ? <SystemHistoryPanel systemState={selectedSystem} /> : null}
 
         <section className="surface overview-panel">
           <div className="section-header">
@@ -178,6 +182,8 @@ export function SystemOverviewRoute({
       ) : null}
 
       {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} storage={storage} /> : null}
+      {selectedSystem ? <FleetAnalyticsPanel systemState={selectedSystem} /> : null}
+      {selectedSystem ? <SystemHistoryPanel systemState={selectedSystem} /> : null}
 
       <section className="surface overview-panel">
         <div className="section-header">

--- a/apps/web/src/features/system/SystemOverviewRoute.tsx
+++ b/apps/web/src/features/system/SystemOverviewRoute.tsx
@@ -1,0 +1,248 @@
+import type { DemoState, WorkflowDemoState } from '../../app/demo';
+import { getAgentLabel, summarizeSystem, type ControlPlaneSystemState } from '../../app/control-plane';
+import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
+import { AgentDetailPanel } from './AgentDetailPanel';
+import { AgentFleetPanel } from './AgentFleetPanel';
+import { SystemCatalogPanel } from './SystemCatalogPanel';
+import { SystemPerformancePanel } from './SystemPerformancePanel';
+
+interface SystemOverviewRouteProps {
+  demoState: DemoState;
+  sortedSystems: ControlPlaneSystemState[];
+  selectedSystem: ControlPlaneSystemState | null;
+  selectedWorkflowState: WorkflowDemoState | null;
+  selectedAgentId: string | null;
+  onSelectSystem: (systemId: string) => void;
+  onSelectAgent: (agentId: string) => void;
+}
+
+function formatTokenLabel(value: string) {
+  return value
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+export function SystemOverviewRoute({
+  demoState,
+  sortedSystems,
+  selectedSystem,
+  selectedWorkflowState,
+  selectedAgentId,
+  onSelectSystem,
+  onSelectAgent,
+}: SystemOverviewRouteProps) {
+  const selectedSystemSummary = summarizeSystem(selectedSystem);
+  const pressureAgentLabel = getAgentLabel(selectedSystem, selectedSystemSummary?.pressureAgentId ?? undefined);
+  const latestRelease = selectedSystemSummary?.latestRelease ?? null;
+  const latestEvaluation = selectedSystemSummary?.latestEvaluation ?? null;
+
+  if (!selectedWorkflowState) {
+    return (
+      <>
+        {sortedSystems.length ? (
+          <SystemCatalogPanel
+            systems={sortedSystems}
+            selectedSystemId={selectedSystem?.system.systemId ?? null}
+            onSelectSystem={onSelectSystem}
+          />
+        ) : null}
+
+        {selectedSystem ? (
+          <section className="system-layout">
+            <AgentFleetPanel
+              systemState={selectedSystem}
+              selectedAgentId={selectedAgentId}
+              onSelectAgent={onSelectAgent}
+            />
+            <AgentDetailPanel systemState={selectedSystem} agentId={selectedAgentId} />
+          </section>
+        ) : null}
+
+        {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} /> : null}
+
+        <section className="surface overview-panel">
+          <div className="section-header">
+            <div>
+              <p className="eyebrow">System overview</p>
+              <h2>Control-plane system summary</h2>
+              <p className="muted overview-panel__body">
+                This system is registered in the control plane, but it does not map to a seeded workflow walkthrough
+                yet. Overview stays useful from the live registry, agent fleet, and release evidence you have already
+                imported.
+              </p>
+            </div>
+            <span className="meta-chip">{demoState.workflows.length} seeded workflow{demoState.workflows.length === 1 ? '' : 's'}</span>
+          </div>
+          <div className="overview-grid">
+            <article className="overview-card overview-card--live">
+              <div className="overview-card__header">
+                <div>
+                  <p className="eyebrow">01 · Live</p>
+                  <h3>{selectedSystem?.system.name ?? 'No system selected'}</h3>
+                </div>
+                <span className={`status-pill status-pill--${selectedSystemSummary?.latestExecution?.status ?? 'active'}`}>
+                  {titleCaseStatus(selectedSystemSummary?.latestExecution?.status ?? 'active')}
+                </span>
+              </div>
+              <p className="overview-card__summary">Operate the actual system registry first: latest execution, active agents, and current pressure.</p>
+              <div className="overview-card__metric">
+                <span>Execution posture</span>
+                <strong>{selectedSystemSummary?.executionCount ?? 0} recorded execution{selectedSystemSummary?.executionCount === 1 ? '' : 's'}</strong>
+              </div>
+              <div className="overview-card__path">
+                <span>{formatCredits(selectedSystemSummary?.avgCredits)}</span>
+                <span>{formatDuration(selectedSystemSummary?.avgDurationMs)}</span>
+              </div>
+            </article>
+            <article className="overview-card overview-card--replay">
+              <div className="overview-card__header">
+                <div>
+                  <p className="eyebrow">02 · Replay</p>
+                  <h3>{pressureAgentLabel ?? 'No hot agent yet'}</h3>
+                </div>
+                <span className={`status-pill status-pill--${selectedSystemSummary?.pressureAgentId ? 'failed' : 'active'}`}>
+                  {selectedSystemSummary?.pressureAgentId ? 'Hot path' : 'Waiting'}
+                </span>
+              </div>
+              <p className="overview-card__summary">Replay gets stronger once this system has imported executions and spans to compare.</p>
+              <div className="overview-card__metric overview-card__metric--warning">
+                <span>Trace pressure</span>
+                <strong>{selectedSystemSummary?.pressureAgentId ? `${pressureAgentLabel} is carrying the most pressure` : 'Import spans to expose the break tree'}</strong>
+              </div>
+              <div className="overview-card__path">
+                <span>{selectedSystemSummary?.agentCount ?? 0} tracked agents</span>
+                <span>{selectedSystemSummary?.activeInterventionCount ?? 0} active directives</span>
+              </div>
+            </article>
+            <article className="overview-card overview-card--optimize">
+              <div className="overview-card__header">
+                <div>
+                  <p className="eyebrow">03 · Optimize</p>
+                  <h3>{latestRelease ? formatTokenLabel(latestRelease.decision) : latestEvaluation ? titleCaseStatus(latestEvaluation.verdict) : 'No release record yet'}</h3>
+                </div>
+                <span className={`status-pill status-pill--${latestRelease?.decision === 'rollback' ? 'failed' : latestRelease ? 'succeeded' : 'active'}`}>
+                  {latestRelease ? 'Release audit' : latestEvaluation ? 'Evaluation' : 'Waiting'}
+                </span>
+              </div>
+              <p className="overview-card__summary">Optimize stays practical only when the system has evaluation and release evidence to work from.</p>
+              <div className="overview-card__metric overview-card__metric--success">
+                <span>Latest decision</span>
+                <strong>{latestRelease?.summary ?? latestEvaluation?.summary ?? 'Import evaluations and releases to light up the workbench.'}</strong>
+              </div>
+              <div className="overview-card__path">
+                <span>{selectedSystemSummary?.interventionCount ?? 0} interventions</span>
+                <span>{selectedSystemSummary?.lastActiveAt ? 'Recently active' : 'No recent release activity'}</span>
+              </div>
+            </article>
+          </div>
+        </section>
+      </>
+    );
+  }
+
+  const workflow = selectedWorkflowState.workflow;
+  const liveRun = selectedWorkflowState.live.run;
+  const replayRun = selectedWorkflowState.replay.run;
+  const failedReplayStep =
+    selectedWorkflowState.replay.replay.stepExecutions.find((step) => step.status === 'failed') ??
+    selectedWorkflowState.replay.replay.stepExecutions[0];
+  const candidateRun = selectedWorkflowState.optimize.candidateRun;
+  const candidateCreditsDelta = (candidateRun.actualCredits ?? 0) - (selectedWorkflowState.optimize.baselineRun.actualCredits ?? 0);
+  const candidateDurationDeltaSeconds = Math.round(
+    ((candidateRun.durationMs ?? 0) - (selectedWorkflowState.optimize.baselineRun.durationMs ?? 0)) / 1000,
+  );
+
+  return (
+    <>
+      {sortedSystems.length ? (
+        <SystemCatalogPanel
+          systems={sortedSystems}
+          selectedSystemId={selectedSystem?.system.systemId ?? null}
+          onSelectSystem={onSelectSystem}
+        />
+      ) : null}
+
+      {selectedSystem ? (
+        <section className="system-layout">
+          <AgentFleetPanel
+            systemState={selectedSystem}
+            selectedAgentId={selectedAgentId}
+            onSelectAgent={onSelectAgent}
+          />
+          <AgentDetailPanel systemState={selectedSystem} agentId={selectedAgentId} />
+        </section>
+      ) : null}
+
+      {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} /> : null}
+
+      <section className="surface overview-panel">
+        <div className="section-header">
+          <div>
+            <p className="eyebrow">System overview</p>
+            <h2>Live, Replay, Optimize</h2>
+            <p className="muted overview-panel__body">This overview shows the current operating loop for the selected system before you drop into a specific room.</p>
+          </div>
+          <span className="meta-chip">{demoState.workflows.length} seeded workflow{demoState.workflows.length === 1 ? '' : 's'}</span>
+        </div>
+        <div className="overview-grid">
+          <article className="overview-card overview-card--live">
+            <div className="overview-card__header">
+              <div>
+                <p className="eyebrow">01 · Live</p>
+                <h3>{liveRun.experimentLabel}</h3>
+              </div>
+              <span className={`status-pill status-pill--${liveRun.status}`}>{titleCaseStatus(liveRun.status)}</span>
+            </div>
+            <p className="overview-card__summary">Operate the current system before you touch history or overrides.</p>
+            <div className="overview-card__metric">
+              <span>Current workflow</span>
+              <strong>{workflow.name}</strong>
+            </div>
+            <div className="overview-card__path">
+              <span>{formatCredits(liveRun.actualCredits)}</span>
+              <span>{formatDuration(liveRun.durationMs)}</span>
+            </div>
+          </article>
+          <article className="overview-card overview-card--replay">
+            <div className="overview-card__header">
+              <div>
+                <p className="eyebrow">02 · Replay</p>
+                <h3>{replayRun.experimentLabel}</h3>
+              </div>
+              <span className={`status-pill status-pill--${replayRun.status}`}>{titleCaseStatus(replayRun.status)}</span>
+            </div>
+            <p className="overview-card__summary">Find the exact break and turn it into the next fix, not another theory.</p>
+            <div className="overview-card__metric overview-card__metric--warning">
+              <span>Pressure point</span>
+              <strong>{failedReplayStep?.title ?? 'No failed step recorded'}</strong>
+            </div>
+            <div className="overview-card__path">
+              <span>{failedReplayStep?.assignedRole ?? 'reviewer'}</span>
+              <span>{formatCredits(replayRun.actualCredits)}</span>
+            </div>
+          </article>
+          <article className="overview-card overview-card--optimize">
+            <div className="overview-card__header">
+              <div>
+                <p className="eyebrow">03 · Optimize</p>
+                <h3>{candidateRun.experimentLabel}</h3>
+              </div>
+              <span className="status-pill status-pill--succeeded">Promotion-ready</span>
+            </div>
+            <p className="overview-card__summary">Compare the candidate against the healthy control and only ship what clearly improves the loop.</p>
+            <div className="overview-card__metric overview-card__metric--success">
+              <span>Release delta</span>
+              <strong>{candidateCreditsDelta < 0 ? `${Math.abs(candidateCreditsDelta)} credits saved` : 'Stable quality retained'}</strong>
+            </div>
+            <div className="overview-card__path">
+              <span>{selectedWorkflowState.optimize.candidatePlan?.name ?? 'Saved plan'}</span>
+              <span>{candidateDurationDeltaSeconds < 0 ? `${Math.abs(candidateDurationDeltaSeconds)}s faster` : 'No speed gain'}</span>
+            </div>
+          </article>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/features/system/SystemOverviewRoute.tsx
+++ b/apps/web/src/features/system/SystemOverviewRoute.tsx
@@ -1,5 +1,16 @@
+import { useMemo, useState } from 'react';
+
 import type { DemoState, WorkflowDemoState } from '../../app/demo';
-import { getAgentLabel, summarizeSystem, type ControlPlaneStorageInfo, type ControlPlaneSystemState } from '../../app/control-plane';
+import {
+  ANALYTICS_WINDOW_OPTIONS,
+  filterSystemStateByWindow,
+  getAgentLabel,
+  getAnalyticsWindowLabel,
+  summarizeSystem,
+  type AnalyticsWindow,
+  type ControlPlaneStorageInfo,
+  type ControlPlaneSystemState,
+} from '../../app/control-plane';
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 import { AgentDetailPanel } from './AgentDetailPanel';
 import { AgentFleetPanel } from './AgentFleetPanel';
@@ -37,10 +48,16 @@ export function SystemOverviewRoute({
   onSelectSystem,
   onSelectAgent,
 }: SystemOverviewRouteProps) {
-  const selectedSystemSummary = summarizeSystem(selectedSystem);
-  const pressureAgentLabel = getAgentLabel(selectedSystem, selectedSystemSummary?.pressureAgentId ?? undefined);
+  const [analyticsWindow, setAnalyticsWindow] = useState<AnalyticsWindow>('7d');
+  const windowedSystemState = useMemo(
+    () => filterSystemStateByWindow(selectedSystem, analyticsWindow),
+    [selectedSystem, analyticsWindow],
+  );
+  const selectedSystemSummary = summarizeSystem(windowedSystemState);
+  const pressureAgentLabel = getAgentLabel(windowedSystemState, selectedSystemSummary?.pressureAgentId ?? undefined);
   const latestRelease = selectedSystemSummary?.latestRelease ?? null;
   const latestEvaluation = selectedSystemSummary?.latestEvaluation ?? null;
+  const windowLabel = getAnalyticsWindowLabel(analyticsWindow);
 
   if (!selectedWorkflowState) {
     return (
@@ -56,17 +73,46 @@ export function SystemOverviewRoute({
         {selectedSystem ? (
           <section className="system-layout">
             <AgentFleetPanel
-              systemState={selectedSystem}
+              systemState={windowedSystemState}
               selectedAgentId={selectedAgentId}
               onSelectAgent={onSelectAgent}
+              analyticsWindow={analyticsWindow}
             />
-            <AgentDetailPanel systemState={selectedSystem} agentId={selectedAgentId} />
+            <AgentDetailPanel systemState={windowedSystemState} agentId={selectedAgentId} />
           </section>
         ) : null}
 
-        {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} storage={storage} /> : null}
-        {selectedSystem ? <FleetAnalyticsPanel systemState={selectedSystem} /> : null}
-        {selectedSystem ? <SystemHistoryPanel systemState={selectedSystem} /> : null}
+        {selectedSystem ? (
+          <section className="surface analytics-query-panel">
+            <div className="section-header">
+              <div>
+                <p className="eyebrow">Analytics scope</p>
+                <h2>Time-windowed system view</h2>
+                <p className="muted">
+                  Filter the control-plane history first. Performance, fleet pressure, and system history all follow
+                  the same window so the operator view stays consistent.
+                </p>
+              </div>
+              <span className="meta-chip">{windowLabel} window</span>
+            </div>
+            <div className="history-toolbar">
+              {ANALYTICS_WINDOW_OPTIONS.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className={`history-filter ${analyticsWindow === option.id ? 'history-filter--active' : ''}`}
+                  onClick={() => setAnalyticsWindow(option.id)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {selectedSystem ? <SystemPerformancePanel systemState={windowedSystemState} storage={storage} analyticsWindow={analyticsWindow} /> : null}
+        {selectedSystem ? <FleetAnalyticsPanel systemState={windowedSystemState} analyticsWindow={analyticsWindow} /> : null}
+        {selectedSystem ? <SystemHistoryPanel systemState={windowedSystemState} analyticsWindow={analyticsWindow} /> : null}
 
         <section className="surface overview-panel">
           <div className="section-header">
@@ -173,17 +219,46 @@ export function SystemOverviewRoute({
       {selectedSystem ? (
         <section className="system-layout">
           <AgentFleetPanel
-            systemState={selectedSystem}
+            systemState={windowedSystemState}
             selectedAgentId={selectedAgentId}
             onSelectAgent={onSelectAgent}
+            analyticsWindow={analyticsWindow}
           />
-          <AgentDetailPanel systemState={selectedSystem} agentId={selectedAgentId} />
+          <AgentDetailPanel systemState={windowedSystemState} agentId={selectedAgentId} />
         </section>
       ) : null}
 
-      {selectedSystem ? <SystemPerformancePanel systemState={selectedSystem} storage={storage} /> : null}
-      {selectedSystem ? <FleetAnalyticsPanel systemState={selectedSystem} /> : null}
-      {selectedSystem ? <SystemHistoryPanel systemState={selectedSystem} /> : null}
+      {selectedSystem ? (
+        <section className="surface analytics-query-panel">
+          <div className="section-header">
+            <div>
+              <p className="eyebrow">Analytics scope</p>
+              <h2>Time-windowed system view</h2>
+              <p className="muted">
+                Filter the control-plane history first. Performance, fleet pressure, and system history all follow the
+                same window so the operator view stays consistent.
+              </p>
+            </div>
+            <span className="meta-chip">{windowLabel} window</span>
+          </div>
+          <div className="history-toolbar">
+            {ANALYTICS_WINDOW_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={`history-filter ${analyticsWindow === option.id ? 'history-filter--active' : ''}`}
+                onClick={() => setAnalyticsWindow(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {selectedSystem ? <SystemPerformancePanel systemState={windowedSystemState} storage={storage} analyticsWindow={analyticsWindow} /> : null}
+      {selectedSystem ? <FleetAnalyticsPanel systemState={windowedSystemState} analyticsWindow={analyticsWindow} /> : null}
+      {selectedSystem ? <SystemHistoryPanel systemState={windowedSystemState} analyticsWindow={analyticsWindow} /> : null}
 
       <section className="surface overview-panel">
         <div className="section-header">

--- a/apps/web/src/features/system/SystemOverviewRoute.tsx
+++ b/apps/web/src/features/system/SystemOverviewRoute.tsx
@@ -14,6 +14,7 @@ import {
 import { formatCredits, formatDuration, titleCaseStatus } from '../../app/format';
 import { AgentDetailPanel } from './AgentDetailPanel';
 import { AgentFleetPanel } from './AgentFleetPanel';
+import { FleetOverviewPanel } from './FleetOverviewPanel';
 import { FleetAnalyticsPanel } from './FleetAnalyticsPanel';
 import { SystemCatalogPanel } from './SystemCatalogPanel';
 import { SystemHistoryPanel } from './SystemHistoryPanel';
@@ -49,6 +50,10 @@ export function SystemOverviewRoute({
   onSelectAgent,
 }: SystemOverviewRouteProps) {
   const [analyticsWindow, setAnalyticsWindow] = useState<AnalyticsWindow>('7d');
+  const fleetSystems = useMemo(
+    () => sortedSystems.map((systemState) => filterSystemStateByWindow(systemState, analyticsWindow) ?? systemState),
+    [analyticsWindow, sortedSystems],
+  );
   const windowedSystemState = useMemo(
     () => filterSystemStateByWindow(selectedSystem, analyticsWindow),
     [selectedSystem, analyticsWindow],
@@ -63,11 +68,14 @@ export function SystemOverviewRoute({
     return (
       <>
         {sortedSystems.length ? (
-          <SystemCatalogPanel
-            systems={sortedSystems}
-            selectedSystemId={selectedSystem?.system.systemId ?? null}
-            onSelectSystem={onSelectSystem}
-          />
+          <>
+            <FleetOverviewPanel systems={fleetSystems} analyticsWindow={analyticsWindow} onSelectSystem={onSelectSystem} />
+            <SystemCatalogPanel
+              systems={fleetSystems}
+              selectedSystemId={selectedSystem?.system.systemId ?? null}
+              onSelectSystem={onSelectSystem}
+            />
+          </>
         ) : null}
 
         {selectedSystem ? (
@@ -209,11 +217,14 @@ export function SystemOverviewRoute({
   return (
     <>
       {sortedSystems.length ? (
-        <SystemCatalogPanel
-          systems={sortedSystems}
-          selectedSystemId={selectedSystem?.system.systemId ?? null}
-          onSelectSystem={onSelectSystem}
-        />
+        <>
+          <FleetOverviewPanel systems={fleetSystems} analyticsWindow={analyticsWindow} onSelectSystem={onSelectSystem} />
+          <SystemCatalogPanel
+            systems={fleetSystems}
+            selectedSystemId={selectedSystem?.system.systemId ?? null}
+            onSelectSystem={onSelectSystem}
+          />
+        </>
       ) : null}
 
       {selectedSystem ? (

--- a/apps/web/src/features/system/SystemPerformancePanel.tsx
+++ b/apps/web/src/features/system/SystemPerformancePanel.tsx
@@ -1,12 +1,13 @@
-import type { ControlPlaneSystemState } from '../../app/control-plane';
+import type { ControlPlaneStorageInfo, ControlPlaneSystemState } from '../../app/control-plane';
 import { getMetricDelta, summarizeAgents, summarizeSystem } from '../../app/control-plane';
 import { formatCredits, formatDateTime, formatDelta, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface SystemPerformancePanelProps {
   systemState: ControlPlaneSystemState | null;
+  storage?: ControlPlaneStorageInfo | null;
 }
 
-export function SystemPerformancePanel({ systemState }: SystemPerformancePanelProps) {
+export function SystemPerformancePanel({ systemState, storage }: SystemPerformancePanelProps) {
   const summary = summarizeSystem(systemState);
   const topAgents = summarizeAgents(systemState).slice(0, 2);
   const latestEvaluation = summary?.latestEvaluation ?? null;
@@ -26,9 +27,16 @@ export function SystemPerformancePanel({ systemState }: SystemPerformancePanelPr
           <h2>{summary.system.name}</h2>
           <p className="muted">Use this before you enter the rooms. It gives the current operating posture, the release posture, and the hottest agents in one place.</p>
         </div>
-        <span className={`status-pill status-pill--${summary.latestExecution?.status ?? summary.system.status ?? 'active'}`}>
-          {titleCaseStatus(summary.latestExecution?.status ?? summary.system.status ?? 'active')}
-        </span>
+        <div className="section-header__meta">
+          <span className={`status-pill status-pill--${summary.latestExecution?.status ?? summary.system.status ?? 'active'}`}>
+            {titleCaseStatus(summary.latestExecution?.status ?? summary.system.status ?? 'active')}
+          </span>
+          {storage ? (
+            <span className="meta-chip">
+              {storage.persistenceEnabled ? 'History persistent' : 'History ephemeral'}
+            </span>
+          ) : null}
+        </div>
       </div>
       <div className="metric-grid">
         <div className="metric-card metric-card--primary">

--- a/apps/web/src/features/system/SystemPerformancePanel.tsx
+++ b/apps/web/src/features/system/SystemPerformancePanel.tsx
@@ -1,0 +1,94 @@
+import type { ControlPlaneSystemState } from '../../app/control-plane';
+import { getMetricDelta, summarizeAgents, summarizeSystem } from '../../app/control-plane';
+import { formatCredits, formatDateTime, formatDelta, formatDuration, titleCaseStatus } from '../../app/format';
+
+interface SystemPerformancePanelProps {
+  systemState: ControlPlaneSystemState | null;
+}
+
+export function SystemPerformancePanel({ systemState }: SystemPerformancePanelProps) {
+  const summary = summarizeSystem(systemState);
+  const topAgents = summarizeAgents(systemState).slice(0, 2);
+  const latestEvaluation = summary?.latestEvaluation ?? null;
+  const latestRelease = summary?.latestRelease ?? null;
+  const creditsDelta = getMetricDelta(latestEvaluation, 'credits.actual');
+  const durationDelta = getMetricDelta(latestEvaluation, 'duration.ms');
+
+  if (!summary) {
+    return null;
+  }
+
+  return (
+    <section className="surface">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Performance cockpit</p>
+          <h2>{summary.system.name}</h2>
+          <p className="muted">Use this before you enter the rooms. It gives the current operating posture, the release posture, and the hottest agents in one place.</p>
+        </div>
+        <span className={`status-pill status-pill--${summary.latestExecution?.status ?? summary.system.status ?? 'active'}`}>
+          {titleCaseStatus(summary.latestExecution?.status ?? summary.system.status ?? 'active')}
+        </span>
+      </div>
+      <div className="metric-grid">
+        <div className="metric-card metric-card--primary">
+          <span>Latest execution</span>
+          <strong>{summary.latestExecution?.metadata?.experimentLabel?.toString() ?? 'No execution yet'}</strong>
+        </div>
+        <div className="metric-card">
+          <span>Avg spend</span>
+          <strong>{formatCredits(summary.avgCredits)}</strong>
+        </div>
+        <div className="metric-card metric-card--accent">
+          <span>Avg duration</span>
+          <strong>{formatDuration(summary.avgDurationMs)}</strong>
+        </div>
+        <div className="metric-card metric-card--success">
+          <span>Success rate</span>
+          <strong>{Math.round(summary.successRate * 100)}%</strong>
+        </div>
+      </div>
+      <div className="signal-band">
+        <article className="signal-band__card">
+          <p className="eyebrow">Execution posture</p>
+          <strong>{summary.latestExecution?.status ? titleCaseStatus(summary.latestExecution.status) : 'No execution'}</strong>
+          <p>{summary.latestExecution ? formatDateTime(summary.latestExecution.finishedAt ?? summary.latestExecution.startedAt) : 'No execution timestamp recorded yet.'}</p>
+        </article>
+        <article className="signal-band__card signal-band__card--accent">
+          <p className="eyebrow">Release posture</p>
+          <strong>{latestRelease ? titleCaseStatus(latestRelease.decision) : 'No release decision'}</strong>
+          <p>{latestRelease?.summary ?? latestEvaluation?.summary ?? 'No release audit has been recorded yet.'}</p>
+        </article>
+        <article className="signal-band__card signal-band__card--directive">
+          <p className="eyebrow">Hottest agents</p>
+          <strong>{topAgents.map((agent) => agent.agent.label).join(' · ') || 'No active agents'}</strong>
+          <p>{topAgents[0] ? `${topAgents[0].activeInterventionCount} directives · ${topAgents[0].failedSpanCount} failed spans` : 'No pressure signal recorded.'}</p>
+        </article>
+      </div>
+      {(creditsDelta || durationDelta || latestRelease) ? (
+        <div className="inline-callout inline-callout--success">
+          <span className="eyebrow">Release audit</span>
+          <p>
+            {latestRelease?.summary ?? latestEvaluation?.summary ?? 'No release summary recorded.'}
+            {creditsDelta ? ` Credits delta ${formatDelta(creditsDelta.delta ?? 0)}.` : ''}
+            {durationDelta ? ` Duration delta ${formatDelta(Math.round((durationDelta.delta ?? 0) / 1000))}s.` : ''}
+          </p>
+        </div>
+      ) : null}
+      {topAgents.length ? (
+        <div className="stack-list">
+          {topAgents.map((agent) => (
+            <div key={agent.agent.agentId} className="stack-list__item stack-list__item--body">
+              <strong>{agent.agent.label}</strong>
+              <p>
+                {Math.round(agent.successRate * 100)}% success · {formatCredits(agent.totalCredits)} total credits · last active{' '}
+                {formatDateTime(agent.lastActiveAt ?? undefined)}
+                {agent.latestSpan ? ` · latest span ${agent.latestSpan.name}` : ''}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/system/SystemPerformancePanel.tsx
+++ b/apps/web/src/features/system/SystemPerformancePanel.tsx
@@ -1,13 +1,14 @@
-import type { ControlPlaneStorageInfo, ControlPlaneSystemState } from '../../app/control-plane';
-import { getMetricDelta, summarizeAgents, summarizeSystem } from '../../app/control-plane';
+import type { AnalyticsWindow, ControlPlaneStorageInfo, ControlPlaneSystemState } from '../../app/control-plane';
+import { getAnalyticsWindowLabel, getMetricDelta, summarizeAgents, summarizeSystem } from '../../app/control-plane';
 import { formatCredits, formatDateTime, formatDelta, formatDuration, titleCaseStatus } from '../../app/format';
 
 interface SystemPerformancePanelProps {
   systemState: ControlPlaneSystemState | null;
   storage?: ControlPlaneStorageInfo | null;
+  analyticsWindow: AnalyticsWindow;
 }
 
-export function SystemPerformancePanel({ systemState, storage }: SystemPerformancePanelProps) {
+export function SystemPerformancePanel({ systemState, storage, analyticsWindow }: SystemPerformancePanelProps) {
   const summary = summarizeSystem(systemState);
   const topAgents = summarizeAgents(systemState).slice(0, 2);
   const latestEvaluation = summary?.latestEvaluation ?? null;
@@ -28,6 +29,7 @@ export function SystemPerformancePanel({ systemState, storage }: SystemPerforman
           <p className="muted">Use this before you enter the rooms. It gives the current operating posture, the release posture, and the hottest agents in one place.</p>
         </div>
         <div className="section-header__meta">
+          <span className="meta-chip">{getAnalyticsWindowLabel(analyticsWindow)} window</span>
           <span className={`status-pill status-pill--${summary.latestExecution?.status ?? summary.system.status ?? 'active'}`}>
             {titleCaseStatus(summary.latestExecution?.status ?? summary.system.status ?? 'active')}
           </span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -687,13 +687,24 @@ li {
 .live-topology {
   display: grid;
   gap: 18px;
-  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.75fr);
   margin-top: 20px;
+}
+
+.live-topology__toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.live-topology__hint {
+  margin: 12px 0 0;
+  color: rgba(238, 244, 255, 0.72);
+  font-size: 0.95rem;
 }
 
 .live-topology__canvas {
   position: relative;
-  min-height: 36rem;
+  min-height: 42rem;
   border-radius: 30px;
   overflow: hidden;
   border: 1px solid rgba(167, 190, 255, 0.12);
@@ -753,7 +764,7 @@ li {
   left: 50%;
   top: 50%;
   z-index: 2;
-  width: min(18rem, calc(100% - 4rem));
+  width: min(20rem, calc(100% - 4rem));
   transform: translate(-50%, -50%);
   border-radius: 28px;
   border: 1px solid rgba(184, 162, 255, 0.2);
@@ -787,7 +798,7 @@ li {
 .live-node {
   position: absolute;
   z-index: 3;
-  width: min(10rem, 24vw);
+  width: clamp(9.25rem, 16vw, 10.75rem);
   transform: translate(-50%, -50%);
   border-radius: 22px;
   border: 1px solid rgba(167, 190, 255, 0.12);
@@ -796,6 +807,18 @@ li {
     linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
     rgba(8, 15, 28, 0.9);
   box-shadow: 0 20px 42px rgba(0, 0, 0, 0.28);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  animation: live-node-float var(--float-duration, 6.8s) ease-in-out infinite;
+  animation-delay: var(--float-delay, 0s);
+  transition:
+    left 220ms ease,
+    top 220ms ease,
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    background 220ms ease,
+    transform 220ms ease;
 }
 
 .live-node--active {
@@ -810,6 +833,14 @@ li {
   background:
     linear-gradient(180deg, rgba(255, 142, 130, 0.12), rgba(255, 255, 255, 0.02)),
     rgba(8, 15, 28, 0.92);
+}
+
+.live-node--dragging {
+  z-index: 8;
+  cursor: grabbing;
+  animation: none;
+  transform: translate(-50%, -50%) scale(1.04);
+  box-shadow: 0 28px 56px rgba(0, 0, 0, 0.38);
 }
 
 .live-node__header {
@@ -876,6 +907,7 @@ li {
 .live-topology__rail {
   display: grid;
   gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .signal-card {
@@ -916,6 +948,17 @@ li {
   gap: 12px;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   margin-top: 18px;
+}
+
+@keyframes live-node-float {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) translateY(0px);
+  }
+
+  50% {
+    transform: translate(-50%, -50%) translateY(-8px);
+  }
 }
 
 .live-topology__stat {
@@ -1068,6 +1111,7 @@ li {
   .advanced-grid,
   .signal-band,
   .live-topology,
+  .live-topology__rail,
   .live-topology__footer,
   .metric-grid,
   .room-section__items {
@@ -1075,30 +1119,26 @@ li {
   }
 
   .live-topology__canvas {
-    min-height: auto;
-    padding: 18px;
-  }
-
-  .live-topology__orbit,
-  .live-topology__glow {
-    display: none;
-  }
-
-  .live-topology__core,
-  .live-node {
-    position: static;
-    width: 100%;
-    transform: none;
-  }
-
-  .live-topology__canvas {
-    display: grid;
-    gap: 12px;
+    min-height: 44rem;
   }
 
   .control-strip {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .live-topology__toolbar {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .live-topology__core {
+    width: min(16rem, calc(100% - 2rem));
+  }
+
+  .live-node {
+    width: min(8.4rem, 38vw);
+    padding: 12px;
   }
 
   .timeline-list__item {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -592,6 +592,91 @@ li {
   margin-top: 20px;
 }
 
+.analytics-grid,
+.analytics-columns,
+.history-toolbar,
+.history-timeline {
+  margin-top: 18px;
+}
+
+.analytics-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.analytics-columns {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.history-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.history-filter {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 9px 14px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.history-filter:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.history-filter--active {
+  border-color: rgba(125, 226, 209, 0.28);
+  background: rgba(125, 226, 209, 0.12);
+  color: var(--text);
+}
+
+.history-timeline {
+  display: grid;
+  gap: 12px;
+}
+
+.history-item {
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  padding: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02)),
+    rgba(7, 14, 28, 0.28);
+}
+
+.history-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.history-item__header h3 {
+  margin: 8px 0 0;
+}
+
+.history-item__summary {
+  margin: 12px 0 0;
+  color: var(--muted);
+}
+
+.history-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .system-card {
   display: grid;
   gap: 16px;
@@ -1618,6 +1703,8 @@ li {
   .loop-grid,
   .overview-grid,
   .ingest-grid,
+  .analytics-grid,
+  .analytics-columns,
   .room-nav__buttons,
   .advanced-grid,
   .signal-band,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -367,6 +367,14 @@ li {
   align-items: start;
 }
 
+.section-header__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .loop-grid,
 .overview-grid,
 .advanced-grid {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3,14 +3,14 @@
   font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  --bg: #110d0e;
-  --bg-accent: #21161b;
-  --surface: rgba(22, 18, 20, 0.86);
-  --surface-strong: rgba(32, 24, 28, 0.94);
-  --border: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 255, 255, 0.14);
-  --text: #f8f3ee;
-  --muted: #c2b6ad;
+  --bg: #07111f;
+  --bg-accent: #15213d;
+  --surface: rgba(9, 18, 35, 0.86);
+  --surface-strong: rgba(12, 24, 46, 0.94);
+  --border: rgba(167, 190, 255, 0.1);
+  --border-strong: rgba(186, 214, 255, 0.18);
+  --text: #eef4ff;
+  --muted: #a4b6d4;
   --gold: #f0b15c;
   --gold-soft: rgba(240, 177, 92, 0.18);
   --cyan: #7de2d1;
@@ -27,9 +27,10 @@ body {
   margin: 0;
   min-width: 320px;
   background:
-    radial-gradient(circle at top left, rgba(240, 177, 92, 0.18), transparent 32%),
-    radial-gradient(circle at top right, rgba(125, 226, 209, 0.14), transparent 24%),
-    linear-gradient(180deg, #1a1417 0%, var(--bg) 48%, #0c090a 100%);
+    radial-gradient(circle at top left, rgba(125, 226, 209, 0.16), transparent 26%),
+    radial-gradient(circle at top center, rgba(184, 162, 255, 0.14), transparent 24%),
+    radial-gradient(circle at top right, rgba(240, 177, 92, 0.12), transparent 22%),
+    linear-gradient(180deg, #0b1730 0%, var(--bg) 42%, #040a14 100%);
   color: var(--text);
 }
 
@@ -69,8 +70,8 @@ li {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+    linear-gradient(rgba(125, 226, 209, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 226, 209, 0.04) 1px, transparent 1px);
   background-size: 38px 38px;
   mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.85), transparent 92%);
   pointer-events: none;
@@ -91,7 +92,7 @@ li {
   border: 1px solid var(--border);
   background: var(--surface);
   backdrop-filter: blur(18px);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.28);
 }
 
 .surface {
@@ -110,9 +111,9 @@ li {
   grid-template-columns: minmax(0, 1.1fr) minmax(280px, 380px);
   align-items: start;
   background:
-    radial-gradient(circle at 18% 12%, rgba(240, 177, 92, 0.18), transparent 28%),
-    radial-gradient(circle at 82% 18%, rgba(125, 226, 209, 0.14), transparent 24%),
-    linear-gradient(135deg, rgba(240, 177, 92, 0.11), transparent 45%),
+    radial-gradient(circle at 18% 12%, rgba(125, 226, 209, 0.16), transparent 26%),
+    radial-gradient(circle at 82% 18%, rgba(184, 162, 255, 0.12), transparent 22%),
+    linear-gradient(135deg, rgba(240, 177, 92, 0.11), transparent 42%),
     linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
   overflow: hidden;
 }
@@ -147,6 +148,16 @@ li {
   pointer-events: none;
 }
 
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(125, 226, 209, 0.12), transparent 22%, transparent 78%, rgba(240, 177, 92, 0.08)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 28%);
+  pointer-events: none;
+}
+
 .hero__current-state {
   margin-top: 22px;
   padding: 18px 20px;
@@ -154,7 +165,7 @@ li {
   border: 1px solid rgba(255, 255, 255, 0.08);
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
-    rgba(8, 7, 8, 0.26);
+    rgba(6, 11, 24, 0.34);
 }
 
 .hero__state-copy strong {
@@ -196,7 +207,7 @@ li {
   border: 1px solid rgba(255, 255, 255, 0.08);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),
-    rgba(10, 8, 9, 0.36);
+    rgba(7, 12, 26, 0.36);
 }
 
 .hero__controls-header h2 {
@@ -215,7 +226,9 @@ li {
   border-radius: 20px;
   padding: 16px;
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.03);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.02)),
+    rgba(255, 255, 255, 0.025);
 }
 
 .hero-signal::before {
@@ -332,7 +345,7 @@ li {
 .loop-grid__card {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),
-    rgba(255, 255, 255, 0.02);
+    rgba(7, 14, 28, 0.24);
 }
 
 .overview-panel__body {
@@ -341,19 +354,19 @@ li {
 
 .overview-card--live {
   background:
-    linear-gradient(180deg, rgba(125, 226, 209, 0.12), rgba(125, 226, 209, 0.03)),
+    linear-gradient(180deg, rgba(125, 226, 209, 0.14), rgba(125, 226, 209, 0.03)),
     var(--surface-strong);
 }
 
 .overview-card--replay {
   background:
-    linear-gradient(180deg, rgba(255, 142, 130, 0.12), rgba(255, 142, 130, 0.03)),
+    linear-gradient(180deg, rgba(184, 162, 255, 0.14), rgba(184, 162, 255, 0.03)),
     var(--surface-strong);
 }
 
 .overview-card--optimize {
   background:
-    linear-gradient(180deg, rgba(240, 177, 92, 0.16), rgba(240, 177, 92, 0.04)),
+    linear-gradient(180deg, rgba(240, 177, 92, 0.18), rgba(240, 177, 92, 0.04)),
     var(--surface-strong);
 }
 
@@ -391,8 +404,8 @@ li {
 }
 
 .overview-card__metric--warning {
-  border-color: rgba(255, 142, 130, 0.2);
-  background: rgba(255, 142, 130, 0.08);
+  border-color: rgba(184, 162, 255, 0.22);
+  background: rgba(184, 162, 255, 0.08);
 }
 
 .overview-card__metric--success {
@@ -436,6 +449,48 @@ li {
   margin-top: 18px;
 }
 
+.control-strip {
+  margin-top: 20px;
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  background:
+    linear-gradient(90deg, rgba(125, 226, 209, 0.08), rgba(184, 162, 255, 0.06) 42%, rgba(240, 177, 92, 0.08)),
+    var(--surface);
+}
+
+.control-strip__copy h2 {
+  margin: 8px 0 0;
+}
+
+.control-strip__copy p {
+  margin: 10px 0 0;
+  max-width: 48rem;
+}
+
+.control-strip__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.control-strip__primary {
+  border: 1px solid rgba(125, 226, 209, 0.28);
+  border-radius: 999px;
+  padding: 11px 18px;
+  background: rgba(125, 226, 209, 0.12);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.control-strip__primary:hover {
+  transform: translateY(-1px);
+  background: rgba(125, 226, 209, 0.18);
+}
+
 .room-tab,
 .ghost-button {
   border: 1px solid var(--border-strong);
@@ -473,10 +528,10 @@ li {
 
 .room-tab--active {
   background:
-    linear-gradient(180deg, rgba(240, 177, 92, 0.16), rgba(240, 177, 92, 0.05)),
+    linear-gradient(180deg, rgba(125, 226, 209, 0.16), rgba(184, 162, 255, 0.08)),
     rgba(255, 255, 255, 0.03);
-  border-color: rgba(240, 177, 92, 0.34);
-  box-shadow: inset 0 0 0 1px rgba(240, 177, 92, 0.16);
+  border-color: rgba(125, 226, 209, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(125, 226, 209, 0.12);
 }
 
 .room-shell__content,
@@ -521,7 +576,7 @@ li {
 
 .metric-grid div {
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.025);
   padding: 14px;
 }
 
@@ -589,7 +644,7 @@ li {
   align-items: start;
   border-radius: 18px;
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.025);
+  background: rgba(255, 255, 255, 0.018);
   padding: 14px;
   position: relative;
 }
@@ -705,6 +760,11 @@ li {
   .metric-grid,
   .room-section__items {
     grid-template-columns: 1fr;
+  }
+
+  .control-strip {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .timeline-list__item {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -92,6 +92,21 @@ li {
   grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.95fr);
 }
 
+.connect-grid,
+.connect-split {
+  display: grid;
+  gap: 14px;
+}
+
+.connect-grid {
+  margin-top: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.connect-split {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .surface,
 .mini-surface,
 .mini-note,
@@ -316,6 +331,18 @@ li {
   color: var(--text);
 }
 
+.text-field textarea {
+  width: 100%;
+  min-height: 7.5rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 18px;
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font: inherit;
+  resize: vertical;
+}
+
 .select-field small,
 .muted {
   color: var(--muted);
@@ -504,7 +531,7 @@ li {
 .room-nav__buttons {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   margin-top: 18px;
 }
 
@@ -755,6 +782,33 @@ li {
 
 .advanced-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.optimize-workbench {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  margin-top: 18px;
+}
+
+.optimize-composer__grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.optimize-composer__grid .mini-note {
+  margin: 0;
+}
+
+.optimize-composer__grid .mini-note strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1rem;
+}
+
+.optimize-composer__grid .mini-note p {
+  margin: 10px 0 0;
 }
 
 .surface--live-brief {
@@ -1386,6 +1440,34 @@ li {
   gap: 12px;
 }
 
+.replay-tree,
+.replay-tree__node,
+.replay-tree__children {
+  display: grid;
+  gap: 12px;
+}
+
+.replay-tree {
+  margin-top: 18px;
+}
+
+.replay-tree__summary,
+.replay-tree__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.replay-tree__summary {
+  margin-top: 18px;
+}
+
+.replay-tree__children {
+  margin-left: 24px;
+  padding-left: 18px;
+  border-left: 1px solid rgba(167, 190, 255, 0.14);
+}
+
 .timeline-list {
   margin-top: 18px;
 }
@@ -1469,6 +1551,22 @@ li {
   gap: 8px;
 }
 
+.optimize-composer__meta,
+.optimize-record__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.optimize-composer__meta {
+  margin-top: 14px;
+}
+
+.optimize-record__meta {
+  margin-top: 10px;
+}
+
 .status-pill,
 .meta-chip {
   display: inline-flex;
@@ -1507,12 +1605,16 @@ li {
 
   .hero,
   .system-layout,
+  .connect-grid,
+  .connect-split,
   .loop-grid,
   .overview-grid,
   .ingest-grid,
   .room-nav__buttons,
   .advanced-grid,
   .signal-band,
+  .optimize-workbench,
+  .optimize-composer__grid,
   .live-topology,
   .live-topology__rail,
   .live-topology__footer,
@@ -1546,6 +1648,11 @@ li {
 
   .timeline-list__item {
     grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .replay-tree__children {
+    margin-left: 14px;
+    padding-left: 12px;
   }
 
   .agent-row {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -85,6 +85,13 @@ li {
   padding: 32px 0 64px;
 }
 
+.system-layout {
+  margin-top: 20px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.95fr);
+}
+
 .surface,
 .mini-surface,
 .mini-note,
@@ -277,6 +284,12 @@ li {
   gap: 8px;
 }
 
+.text-field {
+  display: grid;
+  gap: 8px;
+  margin-top: 18px;
+}
+
 .select-field span,
 .eyebrow {
   font-size: 0.73rem;
@@ -294,6 +307,15 @@ li {
   color: var(--text);
 }
 
+.text-field input {
+  width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: 18px;
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+}
+
 .select-field small,
 .muted {
   color: var(--muted);
@@ -301,6 +323,7 @@ li {
 
 .onboarding-panel,
 .overview-panel,
+.system-catalog,
 .room-nav,
 .room-shell {
   margin-top: 20px;
@@ -322,6 +345,13 @@ li {
 .advanced-grid {
   display: grid;
   gap: 16px;
+}
+
+.ingest-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 18px;
 }
 
 .loop-grid,
@@ -346,6 +376,35 @@ li {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),
     rgba(7, 14, 28, 0.24);
+}
+
+.ingest-card {
+  border-radius: 18px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.ingest-card--ready {
+  border-color: rgba(141, 229, 167, 0.24);
+  background: rgba(141, 229, 167, 0.08);
+}
+
+.ingest-card--thin {
+  border-color: rgba(240, 177, 92, 0.18);
+  background: rgba(240, 177, 92, 0.08);
+}
+
+.ingest-card span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.ingest-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.3rem;
 }
 
 .overview-panel__body {
@@ -489,6 +548,137 @@ li {
 .control-strip__primary:hover {
   transform: translateY(-1px);
   background: rgba(125, 226, 209, 0.18);
+}
+
+.system-catalog__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-top: 20px;
+}
+
+.system-card {
+  display: grid;
+  gap: 16px;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 18px;
+  background:
+    linear-gradient(180deg, rgba(125, 226, 209, 0.1), rgba(255, 255, 255, 0.02)),
+    rgba(7, 14, 28, 0.3);
+  color: var(--text);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.system-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(125, 226, 209, 0.24);
+}
+
+.system-card--active {
+  border-color: rgba(125, 226, 209, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(125, 226, 209, 0.14);
+  background:
+    linear-gradient(180deg, rgba(125, 226, 209, 0.15), rgba(184, 162, 255, 0.06)),
+    rgba(7, 14, 28, 0.38);
+}
+
+.system-card__header,
+.system-card__footer,
+.system-card__metrics {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: start;
+  flex-wrap: wrap;
+}
+
+.system-card__header h3 {
+  margin: 8px 0 0;
+}
+
+.system-card__summary {
+  margin: 0;
+  color: var(--muted);
+  min-height: 3.2rem;
+}
+
+.system-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.system-card__metrics div {
+  border-radius: 18px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.system-card__metrics span {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.system-card__metrics strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.18rem;
+}
+
+.agent-fleet__list,
+.detail-stack {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.agent-row {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.4fr);
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.agent-row:hover {
+  transform: translateY(-1px);
+  border-color: rgba(125, 226, 209, 0.24);
+}
+
+.agent-row--active {
+  border-color: rgba(125, 226, 209, 0.34);
+  background:
+    linear-gradient(180deg, rgba(125, 226, 209, 0.12), rgba(255, 255, 255, 0.025)),
+    rgba(255, 255, 255, 0.025);
+}
+
+.agent-row__identity strong {
+  display: block;
+}
+
+.agent-row__identity span {
+  display: block;
+  margin-top: 6px;
+  color: var(--muted);
+}
+
+.agent-row__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+  color: var(--muted);
+  font-size: 0.92rem;
 }
 
 .room-tab,
@@ -1316,8 +1506,10 @@ li {
   }
 
   .hero,
+  .system-layout,
   .loop-grid,
   .overview-grid,
+  .ingest-grid,
   .room-nav__buttons,
   .advanced-grid,
   .signal-band,
@@ -1354,6 +1546,14 @@ li {
 
   .timeline-list__item {
     grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .agent-row {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-row__metrics {
+    justify-content: start;
   }
 
   .timeline-list__meta {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -693,7 +693,7 @@ li {
 
 .live-topology__canvas {
   position: relative;
-  min-height: 34rem;
+  min-height: 36rem;
   border-radius: 30px;
   overflow: hidden;
   border: 1px solid rgba(167, 190, 255, 0.12);
@@ -787,7 +787,7 @@ li {
 .live-node {
   position: absolute;
   z-index: 3;
-  width: min(11rem, 28vw);
+  width: min(10rem, 24vw);
   transform: translate(-50%, -50%);
   border-radius: 22px;
   border: 1px solid rgba(167, 190, 255, 0.12);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1577,6 +1577,19 @@ li {
   position: relative;
 }
 
+.stack-list__button {
+  width: 100%;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.stack-list__button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(125, 226, 209, 0.24);
+}
+
 .timeline-list__item {
   grid-template-columns: auto minmax(0, 1fr) auto;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -726,6 +726,15 @@ li {
   pointer-events: none;
 }
 
+.live-topology__links {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
 .live-topology__orbit,
 .live-topology__glow {
   position: absolute;
@@ -759,6 +768,40 @@ li {
   filter: blur(18px);
 }
 
+.live-topology__link {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.live-topology__link-glow {
+  stroke-width: 1.2;
+  opacity: 0.26;
+  filter: blur(7px);
+}
+
+.live-topology__link-line {
+  stroke-width: 0.35;
+  stroke-dasharray: 3.4 8.4;
+  animation: live-link-flow 12s linear infinite;
+}
+
+.live-topology__link--standby {
+  stroke: rgba(167, 190, 255, 0.2);
+}
+
+.live-topology__link--active {
+  stroke: rgba(125, 226, 209, 0.52);
+}
+
+.live-topology__link--failed {
+  stroke: rgba(255, 142, 130, 0.62);
+}
+
+.live-topology__link--bottleneck {
+  stroke: rgba(240, 177, 92, 0.78);
+}
+
 .live-topology__core {
   position: absolute;
   left: 50%;
@@ -774,6 +817,7 @@ li {
     linear-gradient(180deg, rgba(184, 162, 255, 0.12), rgba(125, 226, 209, 0.06)),
     rgba(7, 15, 28, 0.84);
   box-shadow: 0 30px 80px rgba(10, 18, 36, 0.46);
+  backdrop-filter: blur(12px);
 }
 
 .live-topology__core strong {
@@ -821,6 +865,15 @@ li {
     transform 220ms ease;
 }
 
+.live-node::after {
+  content: "";
+  position: absolute;
+  inset: -14px;
+  border-radius: 28px;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .live-node--active {
   border-color: rgba(125, 226, 209, 0.24);
   background:
@@ -841,6 +894,19 @@ li {
   animation: none;
   transform: translate(-50%, -50%) scale(1.04);
   box-shadow: 0 28px 56px rgba(0, 0, 0, 0.38);
+}
+
+.live-node--bottleneck {
+  border-color: rgba(240, 177, 92, 0.36);
+  box-shadow:
+    0 24px 50px rgba(0, 0, 0, 0.34),
+    0 0 0 1px rgba(240, 177, 92, 0.12);
+}
+
+.live-node--bottleneck::after {
+  opacity: 1;
+  background: radial-gradient(circle, rgba(240, 177, 92, 0.18), transparent 64%);
+  animation: live-node-pressure 1.9s ease-in-out infinite;
 }
 
 .live-node__header {
@@ -882,6 +948,20 @@ li {
 .live-node__status--failed {
   background: var(--rose);
   box-shadow: 0 0 0 6px rgba(255, 142, 130, 0.12);
+}
+
+.live-node--bottleneck .live-node__status {
+  background: var(--gold);
+  box-shadow: 0 0 0 8px rgba(240, 177, 92, 0.14);
+  animation: live-node-beacon 1.35s ease-in-out infinite;
+}
+
+.live-node__pressure {
+  margin: 10px 0 0;
+  color: var(--gold);
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .live-node__summary {
@@ -958,6 +1038,40 @@ li {
 
   50% {
     transform: translate(-50%, -50%) translateY(-8px);
+  }
+}
+
+@keyframes live-link-flow {
+  from {
+    stroke-dashoffset: 0;
+  }
+
+  to {
+    stroke-dashoffset: -48;
+  }
+}
+
+@keyframes live-node-pressure {
+  0%,
+  100% {
+    transform: scale(0.98);
+    opacity: 0.22;
+  }
+
+  50% {
+    transform: scale(1.04);
+    opacity: 0.5;
+  }
+}
+
+@keyframes live-node-beacon {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.18);
   }
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -694,6 +694,37 @@ li {
   display: flex;
   gap: 12px;
   align-items: center;
+  flex-wrap: wrap;
+}
+
+.live-topology__mode-toggle {
+  display: inline-flex;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(167, 190, 255, 0.14);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.live-topology__mode-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease, transform 180ms ease;
+}
+
+.live-topology__mode-button:hover {
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.live-topology__mode-button--active {
+  background: rgba(125, 226, 209, 0.12);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(125, 226, 209, 0.18);
 }
 
 .live-topology__hint {
@@ -712,6 +743,23 @@ li {
     radial-gradient(circle at center, rgba(125, 226, 209, 0.11), transparent 18%),
     radial-gradient(circle at center, rgba(184, 162, 255, 0.1), transparent 38%),
     linear-gradient(180deg, rgba(8, 15, 28, 0.88), rgba(4, 9, 18, 0.98));
+}
+
+.live-topology__canvas--free {
+  box-shadow:
+    inset 0 0 0 1px rgba(125, 226, 209, 0.08),
+    0 22px 48px rgba(0, 0, 0, 0.24);
+}
+
+.live-topology__canvas--orbit {
+  box-shadow: inset 0 0 0 1px rgba(184, 162, 255, 0.06);
+}
+
+.live-topology__canvas--dragging {
+  background:
+    radial-gradient(circle at center, rgba(125, 226, 209, 0.16), transparent 16%),
+    radial-gradient(circle at center, rgba(184, 162, 255, 0.14), transparent 38%),
+    linear-gradient(180deg, rgba(8, 15, 28, 0.9), rgba(4, 9, 18, 1));
 }
 
 .live-topology__canvas::before {
@@ -802,6 +850,51 @@ li {
   stroke: rgba(240, 177, 92, 0.78);
 }
 
+.live-topology__link--dragging {
+  stroke: rgba(125, 226, 209, 0.92);
+}
+
+.live-topology__canvas--dragging .live-topology__link-line {
+  opacity: 0.32;
+}
+
+.live-topology__canvas--dragging .live-topology__link--dragging.live-topology__link-line {
+  stroke-width: 0.8;
+  opacity: 0.98;
+  stroke-dasharray: 5 6;
+  animation-duration: 3.4s;
+}
+
+.live-topology__canvas--dragging .live-topology__link--dragging.live-topology__link-glow {
+  stroke-width: 2.2;
+  opacity: 0.72;
+  filter: blur(10px);
+}
+
+.live-topology__packet {
+  fill: rgba(125, 226, 209, 0.8);
+  filter: drop-shadow(0 0 5px rgba(125, 226, 209, 0.42));
+  pointer-events: none;
+}
+
+.live-topology__packet--active {
+  fill: rgba(125, 226, 209, 0.86);
+}
+
+.live-topology__packet--failed {
+  fill: rgba(255, 142, 130, 0.86);
+  filter: drop-shadow(0 0 5px rgba(255, 142, 130, 0.4));
+}
+
+.live-topology__packet--bottleneck {
+  fill: rgba(240, 177, 92, 0.9);
+  filter: drop-shadow(0 0 6px rgba(240, 177, 92, 0.48));
+}
+
+.live-topology__packet--dragging {
+  filter: drop-shadow(0 0 8px rgba(125, 226, 209, 0.62));
+}
+
 .live-topology__core {
   position: absolute;
   left: 50%;
@@ -863,6 +956,10 @@ li {
     box-shadow 220ms ease,
     background 220ms ease,
     transform 220ms ease;
+}
+
+.live-topology__canvas--orbit .live-node {
+  cursor: default;
 }
 
 .live-node::after {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -567,6 +567,13 @@ li {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.surface--live-brief {
+  background:
+    radial-gradient(circle at top left, rgba(125, 226, 209, 0.12), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
+    var(--surface);
+}
+
 .metric-grid {
   display: grid;
   gap: 12px;
@@ -625,6 +632,308 @@ li {
   margin: 18px 0 0;
   color: var(--muted);
   font-size: 1rem;
+}
+
+.signal-band {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.signal-band__card {
+  border-radius: 22px;
+  padding: 18px;
+  border: 1px solid rgba(125, 226, 209, 0.14);
+  background:
+    linear-gradient(180deg, rgba(125, 226, 209, 0.08), rgba(255, 255, 255, 0.02)),
+    rgba(255, 255, 255, 0.025);
+}
+
+.signal-band__card--accent {
+  border-color: rgba(184, 162, 255, 0.16);
+  background:
+    linear-gradient(180deg, rgba(184, 162, 255, 0.08), rgba(255, 255, 255, 0.02)),
+    rgba(255, 255, 255, 0.025);
+}
+
+.signal-band__card--directive {
+  border-color: rgba(240, 177, 92, 0.18);
+  background:
+    linear-gradient(180deg, rgba(240, 177, 92, 0.08), rgba(255, 255, 255, 0.02)),
+    rgba(255, 255, 255, 0.025);
+}
+
+.signal-band__card strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.08rem;
+}
+
+.signal-band__card p:last-child {
+  margin: 10px 0 0;
+  color: var(--muted);
+}
+
+.surface--topology {
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 14% 16%, rgba(125, 226, 209, 0.12), transparent 24%),
+    radial-gradient(circle at 84% 12%, rgba(184, 162, 255, 0.11), transparent 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.01)),
+    var(--surface);
+}
+
+.live-topology {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.75fr);
+  margin-top: 20px;
+}
+
+.live-topology__canvas {
+  position: relative;
+  min-height: 34rem;
+  border-radius: 30px;
+  overflow: hidden;
+  border: 1px solid rgba(167, 190, 255, 0.12);
+  background:
+    radial-gradient(circle at center, rgba(125, 226, 209, 0.11), transparent 18%),
+    radial-gradient(circle at center, rgba(184, 162, 255, 0.1), transparent 38%),
+    linear-gradient(180deg, rgba(8, 15, 28, 0.88), rgba(4, 9, 18, 0.98));
+}
+
+.live-topology__canvas::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(125, 226, 209, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 226, 209, 0.05) 1px, transparent 1px);
+  background-size: 34px 34px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.86), transparent 88%);
+  pointer-events: none;
+}
+
+.live-topology__orbit,
+.live-topology__glow {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.live-topology__orbit {
+  border-radius: 50%;
+  border: 1px solid rgba(167, 190, 255, 0.12);
+}
+
+.live-topology__orbit--outer {
+  width: 74%;
+  height: 74%;
+}
+
+.live-topology__orbit--inner {
+  width: 44%;
+  height: 44%;
+  border-color: rgba(125, 226, 209, 0.16);
+}
+
+.live-topology__glow {
+  width: 14rem;
+  height: 14rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(184, 162, 255, 0.26), rgba(125, 226, 209, 0.06) 48%, transparent 70%);
+  filter: blur(18px);
+}
+
+.live-topology__core {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  z-index: 2;
+  width: min(18rem, calc(100% - 4rem));
+  transform: translate(-50%, -50%);
+  border-radius: 28px;
+  border: 1px solid rgba(184, 162, 255, 0.2);
+  padding: 22px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(184, 162, 255, 0.12), rgba(125, 226, 209, 0.06)),
+    rgba(7, 15, 28, 0.84);
+  box-shadow: 0 30px 80px rgba(10, 18, 36, 0.46);
+}
+
+.live-topology__core strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.5rem;
+}
+
+.live-topology__core p:last-of-type {
+  margin: 10px 0 0;
+  color: var(--muted);
+}
+
+.live-topology__core-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.live-node {
+  position: absolute;
+  z-index: 3;
+  width: min(11rem, 28vw);
+  transform: translate(-50%, -50%);
+  border-radius: 22px;
+  border: 1px solid rgba(167, 190, 255, 0.12);
+  padding: 14px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
+    rgba(8, 15, 28, 0.9);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.28);
+}
+
+.live-node--active {
+  border-color: rgba(125, 226, 209, 0.24);
+  background:
+    linear-gradient(180deg, rgba(125, 226, 209, 0.12), rgba(255, 255, 255, 0.02)),
+    rgba(8, 15, 28, 0.92);
+}
+
+.live-node--failed {
+  border-color: rgba(255, 142, 130, 0.26);
+  background:
+    linear-gradient(180deg, rgba(255, 142, 130, 0.12), rgba(255, 255, 255, 0.02)),
+    rgba(8, 15, 28, 0.92);
+}
+
+.live-node__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.live-node__label {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.live-node__meta {
+  margin: 6px 0 0;
+  font-size: 0.76rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.live-node__status {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  margin-top: 4px;
+  border-radius: 999px;
+  background: rgba(167, 190, 255, 0.42);
+}
+
+.live-node__status--active {
+  background: var(--cyan);
+  box-shadow: 0 0 0 6px rgba(125, 226, 209, 0.14);
+}
+
+.live-node__status--failed {
+  background: var(--rose);
+  box-shadow: 0 0 0 6px rgba(255, 142, 130, 0.12);
+}
+
+.live-node__summary {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.live-node__tags,
+.live-node__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.live-node__metrics {
+  color: var(--text);
+  font-size: 0.82rem;
+}
+
+.live-topology__rail {
+  display: grid;
+  gap: 12px;
+}
+
+.signal-card {
+  border-radius: 24px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.015)),
+    rgba(8, 15, 28, 0.82);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.signal-card strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.15rem;
+}
+
+.signal-card p:last-child {
+  margin: 10px 0 0;
+  color: var(--muted);
+}
+
+.signal-card--cyan {
+  border-color: rgba(125, 226, 209, 0.22);
+}
+
+.signal-card--violet {
+  border-color: rgba(184, 162, 255, 0.22);
+}
+
+.signal-card--gold {
+  border-color: rgba(240, 177, 92, 0.24);
+}
+
+.live-topology__footer {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.live-topology__stat {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.015)),
+    rgba(7, 14, 28, 0.42);
+}
+
+.live-topology__stat strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.4rem;
+}
+
+.surface--sequence {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.01)),
+    var(--surface);
 }
 
 .timeline-list,
@@ -757,9 +1066,34 @@ li {
   .overview-grid,
   .room-nav__buttons,
   .advanced-grid,
+  .signal-band,
+  .live-topology,
+  .live-topology__footer,
   .metric-grid,
   .room-section__items {
     grid-template-columns: 1fr;
+  }
+
+  .live-topology__canvas {
+    min-height: auto;
+    padding: 18px;
+  }
+
+  .live-topology__orbit,
+  .live-topology__glow {
+    display: none;
+  }
+
+  .live-topology__core,
+  .live-node {
+    position: static;
+    width: 100%;
+    transform: none;
+  }
+
+  .live-topology__canvas {
+    display: grid;
+    gap: 12px;
   }
 
   .control-strip {

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Start here:
 
+- [Product reset](./product-reset-2026-04-22.md)
+- [Architecture reset](./architecture-reset-2026-04-22.md)
 - [Quickstart](./quickstart.md)
 - [Install](./install.md)
 - [Demo](./demo.md)

--- a/docs/architecture-reset-2026-04-22.md
+++ b/docs/architecture-reset-2026-04-22.md
@@ -1,0 +1,507 @@
+# Agent Studio Architecture Reset
+
+Date: April 22, 2026
+
+## Goal
+
+Turn Agent Studio from a strong single-workflow demo into a practical control plane for user-supplied agent systems.
+
+This document is the concrete architecture plan for doing that.
+
+## Non-Negotiable Product Requirements
+
+The system must support:
+
+- user-supplied agents
+- multiple runtimes
+- many agents in one system
+- real topology
+- replay with retries and branches
+- per-agent and per-run performance measurement
+- manual interventions
+- evidence-backed improvement
+- safe rollout and rollback
+
+If the architecture does not support those, it is not the right architecture.
+
+## Architecture Principle
+
+Keep the current `Workflow` / `Run` / `Replay` experience as a product view.
+
+Do not keep it as the ingestion truth.
+
+The ingestion truth needs to be lower-level and runtime-neutral.
+
+## Core Domain Model
+
+### Registration
+
+`Workspace`
+
+- owner scope
+- access boundary
+
+`RuntimeRegistration`
+
+- `runtimeId`
+- `kind`
+- `adapterId`
+- `adapterVersion`
+- `label`
+- `capabilities`
+- `sourceRef`
+
+`SystemDefinition`
+
+- `systemId`
+- `workspaceId`
+- `name`
+- `description`
+- `runtimeIds[]`
+- `policyRefs[]`
+
+`AgentDefinition`
+
+- `agentId`
+- `systemId`
+- `runtimeId`
+- `label`
+- `kind`
+- `role`
+- `version`
+- `capabilities`
+- `toolRefs[]`
+- `memoryRefs[]`
+
+`TopologySnapshot`
+
+- `snapshotId`
+- `systemId`
+- `capturedAt`
+- `nodes[]`
+- `edges[]`
+- `layoutHints`
+
+### Telemetry
+
+`Execution`
+
+- `executionId`
+- `systemId`
+- `runtimeId`
+- `traceId`
+- `sessionId?`
+- `status`
+- `startedAt`
+- `finishedAt`
+- `sourceRef`
+
+`Span`
+
+- `spanId`
+- `traceId`
+- `executionId`
+- `parentSpanId?`
+- `agentId?`
+- `nodeId?`
+- `kind`
+- `status`
+- `startedAt`
+- `finishedAt`
+- `usage`
+- `attrs`
+- `links[]`
+
+`Artifact`
+
+- `artifactId`
+- `executionId?`
+- `spanId?`
+- `agentId?`
+- `kind`
+- `contentRef`
+- `summary`
+- `derivedFrom[]`
+
+`MetricSample`
+
+- `metric`
+- `unit`
+- `value`
+- `ts`
+- `scopeType`
+- `scopeId`
+- `dimensions`
+
+### Control
+
+`Intervention`
+
+- `interventionId`
+- `targetScope`
+- `actor`
+- `action`
+- `reason`
+- `requestedAt`
+- `appliedAt?`
+- `outcome`
+- `relatedTraceId?`
+- `relatedSpanId?`
+
+`Evaluation`
+
+- `evaluationId`
+- `targetScope`
+- `baselineRefs[]`
+- `candidateRefs[]`
+- `metricDeltas[]`
+- `configPatch`
+- `verdict`
+
+`ReleaseDecision`
+
+- `releaseId`
+- `systemId`
+- `candidateRef`
+- `baselineRef`
+- `decision`
+- `evidenceRefs[]`
+- `rollbackPlan`
+- `appliedAt?`
+
+## Derived Product Views
+
+These should be materialized views or query-layer projections:
+
+- `SystemOverview`
+- `LiveTopologyView`
+- `ReplayView`
+- `OperationalContextView`
+- `OptimizeView`
+- `AgentCatalogView`
+
+This lets us keep a polished operator experience without corrupting the base contract.
+
+## Backend Shape
+
+### Layer 1: Registry API
+
+Responsibilities:
+
+- register runtimes
+- register systems
+- register agents
+- write topology snapshots
+- expose searchable catalog APIs
+
+### Layer 2: Ingest API
+
+Responsibilities:
+
+- append executions
+- append spans
+- append artifacts
+- append metric samples
+- idempotent ingestion
+- batched ingestion
+- backfill ingestion
+
+### Layer 3: Query API
+
+Responsibilities:
+
+- live system state
+- replay reconstruction
+- operational context
+- agent health
+- candidate compare
+- release history
+
+### Layer 4: Control API
+
+Responsibilities:
+
+- scoped directives
+- interventions
+- scenario testing
+- promotion / rollback
+- audit trail
+
+## Storage Recommendation
+
+### Phase 1
+
+- Postgres
+- JSONB
+- pgvector
+- object storage
+
+Why:
+
+- fastest path to a serious product
+- enough for registry + query + operational memory
+- keeps complexity sane
+
+### Phase 2
+
+Add ClickHouse if event volume demands it.
+
+Use it for:
+
+- large span volumes
+- time-series metrics
+- heavy aggregations
+
+Do not start there unless event volume proves the need.
+
+## Adapter Strategy
+
+### First-class adapters
+
+Ship first:
+
+- LangGraph
+- OpenHands
+- CrewAI
+- Microsoft Agent Framework
+
+### Generic ingest path
+
+Support:
+
+- JS SDK
+- Python SDK
+- REST bulk ingest
+- optional OTEL bridge later
+
+### Adapter contract rule
+
+Adapters should translate runtime-specific events into the core contract.
+
+Adapters should not invent product analytics.
+
+Evidence generation belongs in the query and memory layer, not inside adapters.
+
+## Topology Strategy
+
+### What we have to stop doing
+
+- deriving topology only from workflow steps
+- treating roles as stable identity
+- using fixed node counts as layout assumptions
+
+### What we need
+
+- explicit nodes and edges
+- node identity and version
+- runtime boundary awareness
+- groupable clusters
+- transient agent instances
+- active/inactive states
+- edge pressure and failure overlays
+
+### UX implications
+
+Default map behavior should be:
+
+- machine-arranged
+- filterable
+- collapsible
+- searchable
+
+Optional map behavior can still include:
+
+- drag
+- free-arrange
+- local saved layouts
+
+But those are secondary.
+
+## Replay Strategy
+
+Replay should be built from spans and artifacts, not just step summaries.
+
+### The replay UI must support
+
+- branch visibility
+- retry visibility
+- concurrent spans
+- child-agent activity
+- exact evidence trail
+- baseline compare
+- intervention suggestions
+
+### Minimal replay data requirements
+
+- `traceId`
+- parent/child relationships
+- per-span timing
+- per-span status
+- per-span agent attribution
+- artifacts linked to spans
+
+## Metrics Strategy
+
+### The system needs to measure
+
+- latency
+- spend
+- tokens
+- tool failure rate
+- retry rate
+- queueing or wait time when available
+- handoff count
+- intervention rate
+- release win rate
+
+### Scope levels
+
+- per agent
+- per runtime
+- per execution
+- per system
+- per scenario
+
+## Operational Memory Strategy
+
+### Core principle
+
+Operational memory first.
+
+Not generic RAG first.
+
+### Required retrieval jobs
+
+- similar incident retrieval
+- healthy baseline retrieval
+- repeated bottleneck retrieval
+- intervention outcome retrieval
+- release outcome retrieval
+
+### Suggested storage path
+
+Start with:
+
+- Postgres + pgvector
+
+Add later if needed:
+
+- temporal graph layer such as Graphiti
+
+### What not to do
+
+- do not force the whole product through a chat box
+- do not make memory synonymous with embeddings only
+
+## Third-Party Tool Strategy
+
+Use tools to enrich or act, not to define the product.
+
+### Useful tool classes
+
+- tracing providers
+- issue systems
+- GitHub
+- Slack
+- docs and runbooks
+- MCP tool servers
+
+### Tool roles
+
+- attach evidence
+- trigger actions
+- enrich incident context
+- support interventions
+
+## Frontend Product Structure
+
+### Recommended top-level product areas
+
+1. Systems
+- registry and health
+
+2. Live
+- current state and topology
+
+3. Replay
+- run explanation and drift
+
+4. Improve
+- scenarios, interventions, compare
+
+5. Releases
+- promotion, rollback, audit
+
+6. Agents
+- stable agent catalog
+
+### Important product rule
+
+Do not force everything into the current three-room shell if it weakens usability.
+
+Keep the operator loop:
+
+- Live
+- Replay
+- Improve
+
+But support it with:
+
+- Systems
+- Agents
+- Releases
+
+## Phased Roadmap
+
+### Phase 0: Reset
+
+- freeze decorative UI churn
+- redesign contracts
+- define registry + telemetry model
+
+### Phase 1: Control-plane core
+
+- add runtime registration
+- add agent registry
+- add topology snapshots
+- add execution and span ingest
+
+### Phase 2: Practical surfaces
+
+- systems list
+- agent catalog
+- large-scale topology view
+- replay from spans
+
+### Phase 3: Performance and context
+
+- per-agent health
+- incident clustering
+- healthy baseline compare
+- intervention history
+
+### Phase 4: Improvement loop
+
+- scenario testing
+- candidate scoring
+- release decision brief
+- rollback suggestion
+
+### Phase 5: Guarded auto-improvement
+
+- suggested interventions
+- apply-to-candidate
+- canary rollout
+- opt-in auto-loop for narrow scopes
+
+## Next Build Recommendation
+
+Before any major new visual pass, do these in order:
+
+1. redesign the shared contract
+2. implement runtime and agent registry entities
+3. introduce execution/span ingest
+4. rebuild replay on top of spans
+5. redesign the topology view around large-system practicality
+
+That is the shortest path to making Agent Studio a real product instead of an increasingly polished demo.

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,6 +40,27 @@ Run the web app in another terminal:
 VITE_API_URL=http://localhost:4000 corepack pnpm --filter @agent-studio/web dev
 ```
 
+## Persistence
+
+Agent Studio supports:
+
+- ephemeral memory mode
+- self-hosted file persistence
+- hosted Vercel Blob persistence
+
+For self-hosted file persistence:
+
+```bash
+export AGENT_STUDIO_STORE_FILE="$PWD/.agent-studio/store.json"
+corepack pnpm --filter @agent-studio/api dev
+```
+
+For hosted blob persistence on Vercel:
+
+- link a private Blob store to the project so `BLOB_READ_WRITE_TOKEN` is present
+- optionally set `AGENT_STUDIO_BLOB_PATH`
+- the API will automatically switch to blob mode when the token exists
+
 ## Repo layout
 
 - `apps/web` is the public demo shell

--- a/docs/product-reset-2026-04-22.md
+++ b/docs/product-reset-2026-04-22.md
@@ -1,0 +1,684 @@
+# Agent Studio Product Reset
+
+Date: April 22, 2026
+
+## Decision
+
+Yes, there is a real product here.
+
+No, the current standalone app is not that product yet.
+
+The viable product is not:
+
+- a prettier Violema clone
+- a decorative topology map
+- another agent builder
+- a generic RAG chat wrapper
+
+The viable product is:
+
+- an open control plane for bring-your-own agent systems
+- runtime-agnostic
+- replay-first
+- evidence-backed
+- intervention-aware
+- safe to improve over time
+
+If we build that, there is real demand.
+If we keep building a seeded workflow demo with nicer visuals, there is not.
+
+## The Real Reason This App Should Exist
+
+Teams are already building agents with:
+
+- LangGraph
+- OpenHands
+- CrewAI
+- Microsoft Agent Framework
+- Mastra
+- custom internal runtimes
+
+What they still do not have cleanly is one place to answer:
+
+- What agents do I actually have?
+- What is running right now?
+- Which agent or handoff is hurting quality, latency, or spend?
+- What changed between the healthy run and the bad run?
+- What intervention should I try?
+- Did that intervention actually improve the system?
+- Is it safe to roll out wider?
+
+That is the reason Agent Studio should exist.
+
+The product has to help operators manage real systems, not admire them.
+
+## Current Market Reality
+
+As of April 22, 2026, the market is real and crowded.
+
+### Facts
+
+OpenAI is explicitly pushing:
+
+- agent design foundations
+- evals
+- trace grading
+- guardrails
+
+Relevant sources:
+
+- [A practical guide to building agents](https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/)
+- [Trace grading](https://developers.openai.com/api/docs/guides/trace-grading)
+- [Agent evals](https://developers.openai.com/api/docs/guides/agent-evals)
+
+LangSmith is shipping:
+
+- trace debugging
+- dataset experiments
+- cloned threads
+- Studio-based iteration
+
+Source:
+
+- [LangSmith observability Studio](https://docs.langchain.com/langsmith/observability-studio)
+
+Braintrust is strong on:
+
+- evaluations
+- experiments
+- regression discipline
+
+Source:
+
+- [Braintrust evaluations](https://www.braintrust.dev/docs/evaluate/run-evaluations)
+
+CrewAI is shipping its own built-in:
+
+- tracing
+- task execution timelines
+- tool usage visibility
+- LLM call observability
+
+Source:
+
+- [CrewAI tracing](https://docs.crewai.com/en/observability/tracing)
+
+OpenHands now has:
+
+- a real SDK
+- runtime abstraction
+- built-in OTEL-based tracing
+- tool and conversation instrumentation
+
+Sources:
+
+- [OpenHands SDK](https://docs.openhands.dev/sdk/index)
+- [OpenHands observability](https://docs.openhands.dev/sdk/guides/observability)
+
+Microsoft Agent Framework is clearly targeting:
+
+- orchestration
+- deployment
+- multi-agent workflows
+
+Source:
+
+- [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
+
+Phoenix, Mastra, and Portkey are also occupying important adjacencies:
+
+- Phoenix: traces, evals, prompt iteration, experiments
+- Mastra: observability and evals
+- Portkey: gateway, reliability, guardrails, cost/logging
+
+Sources:
+
+- [Phoenix](https://arize.com/docs/phoenix)
+- [Mastra observability](https://mastra.ai/observability)
+- [Portkey agents overview](https://portkey.ai/docs/integrations/agents)
+- [Portkey guardrails](https://portkey.ai/docs/product/guardrails)
+
+### Inference
+
+This category is not empty.
+
+So we cannot win by saying:
+
+- “we also have agents”
+- “we also have traces”
+- “we also have a graph”
+
+We can still win by doing something that is still weak across the market:
+
+- unify observe -> replay -> intervene -> compare -> release
+- across multiple runtimes
+- with a real model of agents, topology, and performance
+
+## Why The Current Standalone Demo Is Not Enough
+
+The current repo is still shaped like:
+
+- one seeded workflow
+- one curated live run
+- one curated bad replay
+- one curated optimize candidate
+
+That makes it a good story demo.
+It does not make it a practical control plane.
+
+### The most important current breaks
+
+1. Identity is weak.
+
+Today the system mostly knows roles and steps, not real agents.
+
+It does not model:
+
+- agent identity
+- agent version
+- agent instance
+- runtime origin
+- topology edges
+- cluster membership
+
+2. Replay is too flat.
+
+It collapses history into a clean storyline instead of preserving:
+
+- retries
+- loops
+- concurrency
+- child agents
+- branch structure
+- cross-runtime spans
+
+3. Metrics are too shallow.
+
+It mostly knows:
+
+- credits
+- duration
+- tokens
+- tool calls
+
+That is not enough for a serious operator.
+
+4. The map is still partly decorative.
+
+It looks much better now, but it still assumes a small curated cast.
+That does not scale to:
+
+- 15 agents
+- 40 agents
+- 200 agents
+
+5. Memory is still a view, not an engine.
+
+We have operational context as a helpful product idea.
+We do not yet have a durable operational memory system that can explain:
+
+- seen-before incidents
+- topology drift
+- policy drift
+- repeated bottlenecks
+- what intervention worked before
+
+## What The Product Must Become
+
+Agent Studio should become a control plane for real multi-agent systems.
+
+That means four practical jobs:
+
+1. Register the system
+The user should be able to connect or declare their actual agents and runtimes.
+
+2. Observe the system
+The system should show current topology, runs, incidents, agent pressure, spend, and latency in a way that still works when the graph is large.
+
+3. Explain the system
+The system should make bad runs legible:
+
+- what happened
+- where it went wrong
+- what changed since healthy
+
+4. Improve the system
+The system should support:
+
+- manual interventions
+- scenario testing
+- candidate comparison
+- guarded rollout
+- rollback
+
+## Core Product Thesis
+
+Recommended category:
+
+- The open control plane for multi-agent systems.
+
+Recommended promise:
+
+- connect your current agents
+- see what they are doing
+- diagnose what changed
+- test a better operating setup
+- roll it out safely
+
+Recommended anti-promise:
+
+- not another framework
+- not another visual builder
+- not another generic observability tool
+- not magical autonomous self-improvement
+
+## Product Model Reset
+
+We should stop thinking in the standalone repo as:
+
+- one workflow with named roles
+
+We should start thinking as:
+
+- workspace
+- runtime
+- system
+- agent
+- topology
+- execution
+- trace/span
+- artifact
+- intervention
+- evaluation
+- release
+
+### The four user-facing objects
+
+The top-level user objects should be:
+
+- System
+- Run
+- Replay
+- Release
+
+Everything else should support those four.
+
+## Frontend Reset
+
+### The graphic environment should be useful, not ornamental
+
+The map should stay visually magnetic.
+But it must operate like an instrument panel, not a poster.
+
+### Required views
+
+1. System overview
+
+Purpose:
+
+- tell the operator whether the system is healthy
+- surface incidents, cost pressure, and hot agents
+
+2. Topology view
+
+Purpose:
+
+- show the live system graph
+- scale beyond a handful of nodes
+
+Requirements:
+
+- zoom and pan
+- search
+- collapse by cluster
+- group by runtime
+- group by role
+- group by sub-system
+- heat overlays for:
+  - latency
+  - failures
+  - retries
+  - spend
+  - intervention targets
+- selectable edges and nodes
+- time-window filter
+- activity playback
+
+3. Replay view
+
+Purpose:
+
+- reconstruct what happened
+- identify the decision point
+
+Requirements:
+
+- phase or span timeline
+- paired baseline comparison
+- branch and retry visibility
+- agent-to-agent handoff trail
+- exact artifacts and evidence trail
+
+4. Improve view
+
+Purpose:
+
+- compare interventions and candidates
+- support release decisions
+
+Requirements:
+
+- scenario-based testing
+- spend / assurance / throughput scoring
+- expected blast radius
+- candidate vs baseline compare
+- promotion and rollback path
+
+5. Agent catalog
+
+Purpose:
+
+- give the user a stable registry of current agents
+
+Requirements:
+
+- agent identity
+- runtime
+- version
+- capabilities
+- recent health
+- recent runs
+- attached tools and memory
+- owning system(s)
+
+### One practical warning
+
+Free-dragging nodes is a nice secondary interaction.
+It cannot be the core topology UX for serious systems.
+
+For large systems, the default needs to be:
+
+- clustered
+- searchable
+- filterable
+- machine-arranged
+
+Free arrange can remain as a local exploration mode.
+
+## Backend Reset
+
+The current control-room contract should become a derived product view, not the source of truth.
+
+### Core backend layers
+
+1. Registration layer
+
+Stores:
+
+- runtimes
+- adapters
+- systems
+- agents
+- topology snapshots
+
+2. Telemetry layer
+
+Stores:
+
+- executions
+- spans
+- artifacts
+- metrics
+- events
+
+3. Control layer
+
+Stores:
+
+- directives
+- interventions
+- experiments
+- evaluations
+- releases
+- rollbacks
+
+4. Operational memory layer
+
+Stores and retrieves:
+
+- similar incidents
+- healthy baselines
+- topology drift
+- intervention outcomes
+- release outcomes
+- evidence provenance
+
+### Recommended core entities
+
+- `RuntimeRegistration`
+- `SystemDefinition`
+- `AgentDefinition`
+- `AgentInstance`
+- `TopologySnapshot`
+- `Execution`
+- `Span`
+- `Artifact`
+- `MetricSample`
+- `Intervention`
+- `Evaluation`
+- `ReleaseDecision`
+
+### Storage recommendation
+
+Phase 1:
+
+- Postgres for registry, control state, and derived views
+- JSONB for flexible adapter payloads
+- object storage for large artifacts
+- pgvector for similarity and incident retrieval
+
+Phase 2 if event volume justifies it:
+
+- ClickHouse for high-volume spans and metric samples
+
+This gives us a practical start without overbuilding early.
+
+## Memory, RAG, And Third-Party Tools
+
+## Memory
+
+The product should center on operational memory, not generic RAG chat.
+
+The memory system should answer:
+
+- Have we seen this before?
+- What changed?
+- What intervention worked last time?
+- Which agents are repeatedly involved?
+- Which topology shape tends to fail?
+
+### Recommended progression
+
+MVP:
+
+- run similarity
+- healthy-baseline retrieval
+- intervention history
+- release outcome retrieval
+
+Later:
+
+- temporal graph layer for causal and relationship-rich context
+
+### Practical technology recommendation
+
+For now:
+
+- Postgres + pgvector
+
+Later, if we need richer temporal relationship retrieval:
+
+- Graphiti as an optional temporal graph layer
+
+Relevant sources:
+
+- [Graphiti](https://github.com/getzep/graphiti)
+- [Mem0 overview](https://docs.mem0.ai/platform/features/platform-overview)
+
+### Important product call
+
+Mem0-style memory can be useful for:
+
+- agent memory
+- user memory
+- session memory
+
+But it should not define the control plane.
+
+Operational memory is the core.
+
+## RAG
+
+Generic doc RAG is not the center of this product.
+
+Useful RAG roles:
+
+- incident evidence retrieval
+- policy or runbook lookup
+- artifact recall
+- tool usage context
+
+Bad role:
+
+- replacing the control plane with a chat box
+
+## Third-party tools
+
+Third-party tools matter, but as helpers, not identity.
+
+Good integration classes:
+
+- MCP servers
+- GitHub
+- Slack
+- incident systems
+- docs and wiki systems
+- tracing providers
+- vector stores
+
+They should help:
+
+- enrich context
+- trigger actions
+- attach evidence
+
+They should not redefine what the product is.
+
+## Is There Demand?
+
+My answer is yes, with one condition:
+
+the product must solve a pain that current runtime-native tools do not solve cleanly.
+
+### Where demand is likely strongest
+
+- AI platform teams
+- teams running coding agents
+- internal ops and workflow automation teams
+- agencies or service teams running repeatable multi-agent systems
+- teams with more than one runtime in the stack
+
+### Where demand is weak
+
+- people who do not already have agent systems
+- teams that only want a chatbot
+- teams that only want prompt analytics
+
+### Demand test we should use
+
+We should treat the next build phase as a demand test, not just a product sprint.
+
+Success looks like:
+
+- at least 3 real runtime integrations
+- at least 5 design partners with existing agent systems
+- repeated use of replay and intervention workflows
+- at least one user changing a system because Agent Studio surfaced the problem clearly
+
+Failure looks like:
+
+- users only admiring the map
+- no one using replay to decide changes
+- no one trusting release recommendations
+
+## Self-Evolving Aspect
+
+Yes, we should keep this.
+
+But it must be earned.
+
+The right progression is:
+
+1. Manual diagnosis
+2. Suggested interventions
+3. Assisted apply-to-candidate
+4. Guarded rollout
+5. Opt-in auto-improvement for narrow scopes
+
+Never skip straight to:
+
+- “the system just evolves itself”
+
+That is hype-first and trust-destroying.
+
+### Guardrails for auto-improvement
+
+- opt-in only
+- scope-limited
+- confidence threshold
+- explainable evidence
+- canary or shadow path first
+- automatic rollback path
+- full audit trail
+
+## What We Should Port From Violema
+
+Do not port the whole surface.
+
+Port the strongest control-room ideas:
+
+- the operator loop
+- the operator brief
+- operational context as an action engine
+- scenario-based optimize flow
+- scoped role or phase interventions
+- paired replay with a clear fix path
+- promotion audit and rollback suggestion
+
+Do not simply port:
+
+- every governance panel
+- every branch-family surface
+- every experimental lab concept
+
+This product needs clarity more than completeness.
+
+## Recommendation
+
+Build Agent Studio.
+
+But reset it around this definition:
+
+- a practical, runtime-agnostic control plane for bring-your-own multi-agent systems
+
+Do not continue the current path as if visual polish alone will get us there.
+
+The next build phase should begin with:
+
+1. control-plane contract redesign
+2. agent and runtime registry
+3. trace and metric ingestion model
+4. topology model that scales
+5. replay and intervention loop
+
+Only then should we do the next serious UI implementation pass.

--- a/packages/contracts/src/control-plane-schemas.ts
+++ b/packages/contracts/src/control-plane-schemas.ts
@@ -1,0 +1,226 @@
+import { z } from 'zod';
+
+import type {
+  AgentDefinition,
+  ArtifactRecord,
+  EvaluationRecord,
+  ExecutionRecord,
+  InterventionRecord,
+  MetricDelta,
+  MetricSample,
+  ReleaseDecision,
+  RuntimeRegistration,
+  SpanLink,
+  SpanRecord,
+  SystemDefinition,
+  TopologyEdge,
+  TopologyNode,
+  TopologySnapshot,
+  UsageStats,
+} from './control-plane-types.js';
+
+const nonEmptyString = z.string().trim().min(1);
+const isoDatetime = z.string().datetime({ offset: true });
+const nonNegativeInt = z.number().int().nonnegative();
+const metadataSchema = z.record(z.string(), z.unknown());
+const dimensionValueSchema = z.union([z.string(), z.number(), z.boolean()]);
+const metricDimensionsSchema = z.record(z.string(), dimensionValueSchema);
+
+export const runtimeRegistrationSchema: z.ZodType<RuntimeRegistration> = z.object({
+  runtimeId: nonEmptyString,
+  kind: nonEmptyString,
+  adapterId: nonEmptyString,
+  adapterVersion: nonEmptyString.optional(),
+  label: nonEmptyString,
+  capabilities: z.array(nonEmptyString).optional(),
+  sourceRef: nonEmptyString.optional(),
+  createdAt: isoDatetime.optional(),
+  updatedAt: isoDatetime.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const systemDefinitionSchema: z.ZodType<SystemDefinition> = z.object({
+  systemId: nonEmptyString,
+  workspaceId: nonEmptyString,
+  name: nonEmptyString,
+  description: nonEmptyString.optional(),
+  runtimeIds: z.array(nonEmptyString),
+  status: nonEmptyString.optional(),
+  primaryRuntimeId: nonEmptyString.optional(),
+  policyRefs: z.array(nonEmptyString).optional(),
+  createdAt: isoDatetime.optional(),
+  updatedAt: isoDatetime.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const agentDefinitionSchema: z.ZodType<AgentDefinition> = z.object({
+  agentId: nonEmptyString,
+  systemId: nonEmptyString,
+  runtimeId: nonEmptyString,
+  label: nonEmptyString,
+  kind: nonEmptyString,
+  role: nonEmptyString.optional(),
+  version: nonEmptyString.optional(),
+  capabilities: z.array(nonEmptyString).optional(),
+  toolRefs: z.array(nonEmptyString).optional(),
+  memoryRefs: z.array(nonEmptyString).optional(),
+  status: nonEmptyString.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const topologyNodeSchema: z.ZodType<TopologyNode> = z.object({
+  nodeId: nonEmptyString,
+  agentId: nonEmptyString.optional(),
+  runtimeId: nonEmptyString.optional(),
+  label: nonEmptyString,
+  kind: nonEmptyString,
+  role: nonEmptyString.optional(),
+  clusterId: nonEmptyString.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const topologyEdgeSchema: z.ZodType<TopologyEdge> = z.object({
+  edgeId: nonEmptyString,
+  sourceNodeId: nonEmptyString,
+  targetNodeId: nonEmptyString,
+  kind: nonEmptyString,
+  label: nonEmptyString.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const topologySnapshotSchema: z.ZodType<TopologySnapshot> = z.object({
+  snapshotId: nonEmptyString,
+  systemId: nonEmptyString,
+  capturedAt: isoDatetime,
+  sourceExecutionId: nonEmptyString.optional(),
+  nodes: z.array(topologyNodeSchema),
+  edges: z.array(topologyEdgeSchema),
+  layoutHints: metadataSchema.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const usageStatsSchema: z.ZodType<UsageStats> = z.object({
+  inputTokens: nonNegativeInt.optional(),
+  outputTokens: nonNegativeInt.optional(),
+  totalTokens: nonNegativeInt.optional(),
+  credits: z.number().nonnegative().optional(),
+  durationMs: nonNegativeInt.optional(),
+  toolCalls: nonNegativeInt.optional(),
+});
+
+export const executionRecordSchema: z.ZodType<ExecutionRecord> = z.object({
+  executionId: nonEmptyString,
+  systemId: nonEmptyString,
+  runtimeId: nonEmptyString,
+  traceId: nonEmptyString,
+  sessionId: nonEmptyString.optional(),
+  workflowId: nonEmptyString.optional(),
+  runId: nonEmptyString.optional(),
+  status: nonEmptyString,
+  startedAt: isoDatetime,
+  finishedAt: isoDatetime.optional(),
+  sourceRef: nonEmptyString.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const spanLinkSchema: z.ZodType<SpanLink> = z.object({
+  spanId: nonEmptyString,
+  relation: nonEmptyString.optional(),
+});
+
+export const spanRecordSchema: z.ZodType<SpanRecord> = z.object({
+  spanId: nonEmptyString,
+  traceId: nonEmptyString,
+  executionId: nonEmptyString,
+  parentSpanId: nonEmptyString.optional(),
+  agentId: nonEmptyString.optional(),
+  nodeId: nonEmptyString.optional(),
+  name: nonEmptyString,
+  kind: nonEmptyString,
+  status: nonEmptyString,
+  startedAt: isoDatetime,
+  finishedAt: isoDatetime.optional(),
+  summary: nonEmptyString.optional(),
+  usage: usageStatsSchema.optional(),
+  attrs: metadataSchema.optional(),
+  links: z.array(spanLinkSchema).optional(),
+});
+
+export const artifactRecordSchema: z.ZodType<ArtifactRecord> = z.object({
+  artifactId: nonEmptyString,
+  kind: nonEmptyString,
+  scopeType: nonEmptyString,
+  scopeId: nonEmptyString,
+  executionId: nonEmptyString.optional(),
+  spanId: nonEmptyString.optional(),
+  agentId: nonEmptyString.optional(),
+  contentRef: nonEmptyString.optional(),
+  summary: nonEmptyString.optional(),
+  derivedFromArtifactIds: z.array(nonEmptyString).optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const metricSampleSchema: z.ZodType<MetricSample> = z.object({
+  sampleId: nonEmptyString,
+  metric: nonEmptyString,
+  unit: nonEmptyString,
+  value: z.number(),
+  ts: isoDatetime,
+  scopeType: nonEmptyString,
+  scopeId: nonEmptyString,
+  dimensions: metricDimensionsSchema.optional(),
+});
+
+export const interventionRecordSchema: z.ZodType<InterventionRecord> = z.object({
+  interventionId: nonEmptyString,
+  targetScopeType: nonEmptyString,
+  targetScopeId: nonEmptyString,
+  actor: nonEmptyString,
+  action: nonEmptyString,
+  reason: nonEmptyString,
+  requestedAt: isoDatetime,
+  appliedAt: isoDatetime.optional(),
+  outcome: nonEmptyString.optional(),
+  status: nonEmptyString.optional(),
+  relatedTraceId: nonEmptyString.optional(),
+  relatedSpanId: nonEmptyString.optional(),
+  configPatch: metadataSchema.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const metricDeltaSchema: z.ZodType<MetricDelta> = z.object({
+  metric: nonEmptyString,
+  unit: nonEmptyString.optional(),
+  baselineValue: z.number().optional(),
+  candidateValue: z.number().optional(),
+  delta: z.number().optional(),
+});
+
+export const evaluationRecordSchema: z.ZodType<EvaluationRecord> = z.object({
+  evaluationId: nonEmptyString,
+  targetScopeType: nonEmptyString,
+  targetScopeId: nonEmptyString,
+  baselineRefs: z.array(nonEmptyString),
+  candidateRefs: z.array(nonEmptyString),
+  metricDeltas: z.array(metricDeltaSchema).optional(),
+  configPatch: metadataSchema.optional(),
+  verdict: nonEmptyString,
+  createdAt: isoDatetime,
+  summary: nonEmptyString.optional(),
+  metadata: metadataSchema.optional(),
+});
+
+export const releaseDecisionSchema: z.ZodType<ReleaseDecision> = z.object({
+  releaseId: nonEmptyString,
+  systemId: nonEmptyString,
+  candidateRef: nonEmptyString,
+  baselineRef: nonEmptyString.optional(),
+  decision: nonEmptyString,
+  evidenceRefs: z.array(nonEmptyString).optional(),
+  rollbackPlan: nonEmptyString.optional(),
+  requestedAt: isoDatetime,
+  appliedAt: isoDatetime.optional(),
+  status: nonEmptyString.optional(),
+  summary: nonEmptyString.optional(),
+  metadata: metadataSchema.optional(),
+});

--- a/packages/contracts/src/control-plane-types.ts
+++ b/packages/contracts/src/control-plane-types.ts
@@ -1,0 +1,202 @@
+export type MetadataMap = Record<string, unknown>;
+export type MetricDimensionValue = string | number | boolean;
+export type MetricDimensions = Record<string, MetricDimensionValue>;
+
+export interface RuntimeRegistration {
+  runtimeId: string;
+  kind: string;
+  adapterId: string;
+  adapterVersion?: string;
+  label: string;
+  capabilities?: string[];
+  sourceRef?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  metadata?: MetadataMap;
+}
+
+export interface SystemDefinition {
+  systemId: string;
+  workspaceId: string;
+  name: string;
+  description?: string;
+  runtimeIds: string[];
+  status?: string;
+  primaryRuntimeId?: string;
+  policyRefs?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  metadata?: MetadataMap;
+}
+
+export interface AgentDefinition {
+  agentId: string;
+  systemId: string;
+  runtimeId: string;
+  label: string;
+  kind: string;
+  role?: string;
+  version?: string;
+  capabilities?: string[];
+  toolRefs?: string[];
+  memoryRefs?: string[];
+  status?: string;
+  metadata?: MetadataMap;
+}
+
+export interface TopologyNode {
+  nodeId: string;
+  agentId?: string;
+  runtimeId?: string;
+  label: string;
+  kind: string;
+  role?: string;
+  clusterId?: string;
+  metadata?: MetadataMap;
+}
+
+export interface TopologyEdge {
+  edgeId: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  kind: string;
+  label?: string;
+  metadata?: MetadataMap;
+}
+
+export interface TopologySnapshot {
+  snapshotId: string;
+  systemId: string;
+  capturedAt: string;
+  sourceExecutionId?: string;
+  nodes: TopologyNode[];
+  edges: TopologyEdge[];
+  layoutHints?: MetadataMap;
+  metadata?: MetadataMap;
+}
+
+export interface UsageStats {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  credits?: number;
+  durationMs?: number;
+  toolCalls?: number;
+}
+
+export interface ExecutionRecord {
+  executionId: string;
+  systemId: string;
+  runtimeId: string;
+  traceId: string;
+  sessionId?: string;
+  workflowId?: string;
+  runId?: string;
+  status: string;
+  startedAt: string;
+  finishedAt?: string;
+  sourceRef?: string;
+  metadata?: MetadataMap;
+}
+
+export interface SpanLink {
+  spanId: string;
+  relation?: string;
+}
+
+export interface SpanRecord {
+  spanId: string;
+  traceId: string;
+  executionId: string;
+  parentSpanId?: string;
+  agentId?: string;
+  nodeId?: string;
+  name: string;
+  kind: string;
+  status: string;
+  startedAt: string;
+  finishedAt?: string;
+  summary?: string;
+  usage?: UsageStats;
+  attrs?: MetadataMap;
+  links?: SpanLink[];
+}
+
+export interface ArtifactRecord {
+  artifactId: string;
+  kind: string;
+  scopeType: string;
+  scopeId: string;
+  executionId?: string;
+  spanId?: string;
+  agentId?: string;
+  contentRef?: string;
+  summary?: string;
+  derivedFromArtifactIds?: string[];
+  metadata?: MetadataMap;
+}
+
+export interface MetricSample {
+  sampleId: string;
+  metric: string;
+  unit: string;
+  value: number;
+  ts: string;
+  scopeType: string;
+  scopeId: string;
+  dimensions?: MetricDimensions;
+}
+
+export interface InterventionRecord {
+  interventionId: string;
+  targetScopeType: string;
+  targetScopeId: string;
+  actor: string;
+  action: string;
+  reason: string;
+  requestedAt: string;
+  appliedAt?: string;
+  outcome?: string;
+  status?: string;
+  relatedTraceId?: string;
+  relatedSpanId?: string;
+  configPatch?: MetadataMap;
+  metadata?: MetadataMap;
+}
+
+export interface MetricDelta {
+  metric: string;
+  unit?: string;
+  baselineValue?: number;
+  candidateValue?: number;
+  delta?: number;
+}
+
+export interface EvaluationRecord {
+  evaluationId: string;
+  targetScopeType: string;
+  targetScopeId: string;
+  baselineRefs: string[];
+  candidateRefs: string[];
+  metricDeltas?: MetricDelta[];
+  configPatch?: MetadataMap;
+  verdict: string;
+  createdAt: string;
+  summary?: string;
+  metadata?: MetadataMap;
+}
+
+export interface ReleaseDecision {
+  releaseId: string;
+  systemId: string;
+  candidateRef: string;
+  baselineRef?: string;
+  decision: string;
+  evidenceRefs?: string[];
+  rollbackPlan?: string;
+  requestedAt: string;
+  appliedAt?: string;
+  status?: string;
+  summary?: string;
+  metadata?: MetadataMap;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js';
+export * from './control-plane-types.js';
 export {
   directiveModeSchema,
   executionModeSchema,
@@ -27,3 +28,21 @@ export {
   workflowStepSchema,
   workspaceSchema,
 } from './schemas.js';
+export {
+  agentDefinitionSchema,
+  artifactRecordSchema,
+  evaluationRecordSchema,
+  executionRecordSchema,
+  interventionRecordSchema,
+  metricDeltaSchema,
+  metricSampleSchema,
+  releaseDecisionSchema,
+  runtimeRegistrationSchema,
+  spanLinkSchema,
+  spanRecordSchema,
+  systemDefinitionSchema,
+  topologyEdgeSchema,
+  topologyNodeSchema,
+  topologySnapshotSchema,
+  usageStatsSchema,
+} from './control-plane-schemas.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@agent-studio/demo':
         specifier: workspace:*
         version: link:../../packages/demo
+      '@vercel/blob':
+        specifier: ^2.3.3
+        version: 2.3.3
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -790,6 +793,10 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@vercel/blob@2.3.3':
+    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+    engines: {node: '>=20.0.0'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -847,6 +854,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1048,9 +1058,16 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-network-error@1.3.1:
     resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
     engines: {node: '>=16'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1187,6 +1204,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1231,6 +1252,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1277,6 +1302,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1871,6 +1900,14 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@vercel/blob@2.3.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.25.0
+
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.17))':
     dependencies:
       '@babel/core': 7.29.0
@@ -1936,6 +1973,10 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   asynckit@0.4.0: {}
 
@@ -2169,7 +2210,11 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  is-buffer@2.0.5: {}
+
   is-network-error@1.3.1: {}
+
+  is-node-process@1.2.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -2299,6 +2344,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  retry@0.13.1: {}
+
   rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -2360,6 +2407,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  throttleit@2.1.0: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2394,6 +2443,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@6.25.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,14 @@
     {
       "source": "/api/(.*)",
       "destination": "/api/router?path=$1"
+    },
+    {
+      "source": "/connect",
+      "destination": "/"
+    },
+    {
+      "source": "/systems/(.*)",
+      "destination": "/"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- pull the standalone Agent Studio shell closer to the Violema control-room visual language
- add a mode-to-mode control loop strip so the public demo feels like one operating system
- shift the visual system from warm demo minimalism toward the stronger navy/cyan command-center tone

## Validation
- corepack pnpm --filter @agent-studio/web test
- corepack pnpm lint
- corepack pnpm build
- redeployed production alias and verified /, /health, and /api/demo/state all return 200
